### PR TITLE
Fix: typescript plugin err

### DIFF
--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -105,7 +105,7 @@ export function getNodeIdentifier(
 export function getNodeType(node: ts.Node, typechecker: ts.TypeChecker) {
   const declaration = typechecker.getSymbolAtLocation(node);
 
-  if (!(node.parent || declaration.valueDeclaration)) {
+  if (!(declaration.valueDeclaration && node.parent)) {
     return;
   }
 


### PR DESCRIPTION
The previously written logic didn't correctly check for undefined values in a helper function resulting to TypeScript attempting to run a `isMethod` checker on undefined values and erroring out. This fixes that.