### PR TITLE
Add push gateway config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ lerna-debug.log*
 /.nyc_output
 
 # IDEs and editors
+.vscode
 /.idea
 .project
 .classpath

--- a/README.md
+++ b/README.md
@@ -225,8 +225,12 @@ data to. You can also set the push interval with the `pushInterval` property
 (default is every 5000 miliseconds);
 
 ```typescript
-init({ pushGateway: "<link_to_gateway>" });
+init({ pushGateway: "<link_to_gateway>", pushInterval: 10000 });
 ```
+
+For both the `pushGateway` and `pushInterval` options, the init function will try to fall back to the `PROMETHEUS_PUSHGATEWAY_URL` and `PROMETHEUS_PUSHGATEWAY_INTERVAL` environment variables, respectively.
+
+**The options supplied to the `init` function always take precedence over their corresponding environment variables.**
 
 ### Use Autometrics wrapper with options
 

--- a/packages/autometrics-lib/src/config.ts
+++ b/packages/autometrics-lib/src/config.ts
@@ -1,0 +1,84 @@
+import { MetricReader } from "@opentelemetry/sdk-metrics";
+
+type Exporter = MetricReader;
+
+export type InitOptions = {
+  /**
+   * A custom exporter to be used instead of the bundled Prometheus Exporter on port 9464
+   */
+  exporter?: Exporter;
+  /**
+   * The full URL (including http://) of the aggregating push gateway for metrics to be submitted to.
+   * Will override the exporter if provided.
+   */
+  pushGateway?: string;
+  /**
+   * Set a custom push interval in ms (default: 5000ms)
+   */
+  pushInterval?: number;
+};
+
+/**
+ * Employ a "last-in-wins" strategy to merge two InitOptions objects.
+ */
+export function mergeInitOptions(
+  envOptions: InitOptions,
+  initFunctionOptions: InitOptions,
+): InitOptions {
+  return {
+    ...envOptions,
+    ...initFunctionOptions,
+  };
+}
+
+/**
+ * Safely read `pushGateway` and `pushInterval` initOptions from the environment.
+ * If the environment variables are not set, returns an empty object.
+ */
+export function getInitConfigFromEnv(): InitOptions {
+  let config: InitOptions = {};
+
+  const pushGateway = getPushGatewayFromEnv();
+  if (pushGateway) {
+    config.pushGateway = pushGateway;
+  }
+
+  const pushInterval = parseInt(getPushGatewayIntervalFromEnv());
+  if (!isNaN(pushInterval)) {
+    config.pushInterval = pushInterval;
+  }
+
+  return config;
+}
+
+/**
+ * Safely access the PROMETHEUS_PUSHGATEWAY_URL key on `process.env`, if it exists.
+ *
+ * NOTE - We access the value directly on `process.env` to play nicely with Parcel, which does not allow you to pass around `process.env` as an object.
+ */
+const getPushGatewayFromEnv = () => {
+  if (
+    typeof process !== "undefined" &&
+    process?.env?.PROMETHEUS_PUSHGATEWAY_URL
+  ) {
+    return process.env.PROMETHEUS_PUSHGATEWAY_URL;
+  }
+
+  return null;
+};
+
+/**
+ * Safely access the PROMETHEUS_PUSHGATEWAY_INTERVAL key on `process.env`, if it exists.
+ *
+ * NOTE - We access the value directly on `process.env` to play nicely with Parcel, which does not allow you to pass around `process.env` as an object.
+ */
+const getPushGatewayIntervalFromEnv = () => {
+  if (
+    typeof process !== "undefined" &&
+    process?.env?.PROMETHEUS_PUSHGATEWAY_INTERVAL
+  ) {
+    return process.env.PROMETHEUS_PUSHGATEWAY_INTERVAL;
+  }
+
+  return null;
+};

--- a/packages/autometrics-lib/src/instrumentation.ts
+++ b/packages/autometrics-lib/src/instrumentation.ts
@@ -9,33 +9,22 @@ import {
   PeriodicExportingMetricReader,
 } from "@opentelemetry/sdk-metrics";
 
+import { InitOptions, getInitConfigFromEnv, mergeInitOptions } from "./config";
+
 let autometricsMeterProvider: MeterProvider;
 let exporter: MetricReader;
-
-type Exporter = MetricReader;
-
-export type initOptions = {
-  /**
-   * A custom exporter to be used instead of the bundled Prometheus Exporter on port 9464
-   */
-  exporter?: Exporter;
-  /**
-   * The full URL (including http://) of the aggregating push gateway for metrics to be submitted to.
-   */
-  pushGateway?: string;
-  /**
-   * Set a custom push interval in ms (default: 5000ms)
-   */
-  pushInterval?: number;
-};
 
 /**
  * Optional initialization function to set a custom exporter or push gateway for client-side applications.
  * Required if using autometrics in a client-side application.
  *
- * @param {initOptions} options
+ * @param {InitOptions} options
  */
-export function init(options: initOptions) {
+export function init(options: InitOptions) {
+  // Read options from the environment and merge with the options supplied to this function
+  // The options supplied to this function take precedence
+  options = mergeInitOptions(getInitConfigFromEnv(), options);
+
   logger("Using the user's Exporter configuration");
   exporter = options.exporter;
   // if a pushGateway is added we overwrite the exporter

--- a/packages/autometrics-lib/tests/confg.test.ts
+++ b/packages/autometrics-lib/tests/confg.test.ts
@@ -1,0 +1,36 @@
+import { getInitConfigFromEnv } from "../src/config";
+import { describe, test, expect, beforeAll, afterEach } from "vitest";
+
+// Restore the original environment variables after each test
+let originalEnv: NodeJS.ProcessEnv;
+beforeAll(() => {
+  originalEnv = process.env;
+});
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("Autometrics configuration from environment vars", () => {
+  test("returns empty object when no environment vars present", () => {
+    expect(getInitConfigFromEnv()).to.be.empty;
+  });
+
+  test("returns correct pushGateway when PROMETHEUS_PUSHGATEWAY_URL is present", () => {
+    process.env.PROMETHEUS_PUSHGATEWAY_URL = "http://localhost:9091";
+    expect(getInitConfigFromEnv()).to.have.property("pushGateway");
+    expect(getInitConfigFromEnv().pushGateway).to.equal(
+      "http://localhost:9091",
+    );
+  });
+
+  test("returns correct pushInterval when PROMETHEUS_PUSHGATEWAY_INTERVAL is present and an integer", () => {
+    process.env.PROMETHEUS_PUSHGATEWAY_INTERVAL = "90000";
+    expect(getInitConfigFromEnv()).to.have.property("pushInterval");
+    expect(getInitConfigFromEnv().pushInterval).to.equal(90000);
+  });
+
+  test("does not set pushInterval when PROMETHEUS_PUSHGATEWAY_INTERVAL is not an integer", () => {
+    process.env.PROMETHEUS_PUSHGATEWAY_INTERVAL = "xyz";
+    expect(getInitConfigFromEnv()).not.to.have.property("pushInterval");
+  });
+});


### PR DESCRIPTION
Simple PR to allow push gateway configuration via env vars `PROMETHEUS_PUSHGATEWAY_URL` and `PROMETHEUS_PUSHGATEWAY_INTERVAL`

You still need to call `init` to use a push gateway. And options supplied to the `init` function will always take precedence over env vars.

This PR includes tests yayyyyy