### PR TITLE
Add launch.json configs for easier TypeScript debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch VSCode",
+      "type": "node",
+      "request": "launch",
+      "env": {
+        "TSS_DEBUG_BRK": "9229"
+      },
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "code",
+      "runtimeArgs": ["-n", "--disable-extensions", "${input:pickExample}"],
+      "restart": true
+    },
+    {
+      "name": "Attach to VSCode",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "restart": true,
+      "sourceMaps": true,
+    }
+  ],
+  "inputs": [
+    {
+      "id": "pickExample",
+      "type": "pickString",
+      "description": "Pick an example to run",
+      "options": [
+        "examples/express",
+        "examples/fastify",
+        "examples/nestjs",
+        "examples/react-app",
+        "examples/svelte-app",
+      ]
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,18 @@ work and feel like.
 
 #### Debugging TypeScript plugin
 
+0. Run `Launch VSCode` and `Attach VSCode` in debugger
+
+The repo includes two launch configurations, one to launch a VSCode instance for
+debugging (with no extensions running to prevent conflicts), and another to
+attach the "host" VSCode debugger. They are both separated as you might need to
+reattach the host debugger multiple times during the workflow.
+
+To run either of the commands simply select any of the launch configurations in 
+the debugger section of your main VSCode window. The "Launch VSCode" command
+will prompt you to select an example project that you'd want to use for testing
+(make sure your local development version TypeScript plugin is installed there).
+
 1. Console.log
 
 You can use `console.log` to debug like in any application. To see the logs in

--- a/examples/react-app/.gitignore
+++ b/examples/react-app/.gitignore
@@ -13,8 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/examples/svelte-app/.gitignore
+++ b/examples/svelte-app/.gitignore
@@ -13,8 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo


### PR DESCRIPTION
This PR adds simple `launch.json` configs that will help make debugging
TypeScript plugin easier. The two commands:

1. Launch VSCode (for debugging) - launches a simple VSCode instance (no
   extensions running) with a breakpoint configured on port `9229` that a
   debugger can attach to.

2. Attach VSCode - attaches the host VSCode to the running "guest" VSCode

- remove gitignores that were intruding
- add launch.json config
- update docs
