### PR TITLE
Add support for applying autometrics decorator to classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,29 @@ Here's a snippet from the example code:
 ```typescript
 import { Controller, Get } from "@nestjs/common";
 import { AppService } from "./app.service";
-import { autometricsMethodDecorator as autometrics } from "autometrics";
+import { Autometrics } from "autometrics";
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  @autometrics
+  @Autometrics()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}
+```
+
+Alternatively, you can apply the same decorator to a class to instrument all of
+its methods:
+
+```typescript
+// ...
+@Autometrics()
+export class AppController {
+  // ...
+  @Get()
   getHello(): string {
     return this.appService.getHello();
   }

--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ const user = createUser();
 
 ### Decorating class methods
 
-When using a decorator fora class method, it is wrapped in additional
-code that instruments the method with OpenTelemetry metrics.
+When using a decorator for a class method, it is wrapped in additional code that
+instruments the method with OpenTelemetry metrics.
 
 Here's a snippet from the example code:
 
 ```typescript
 import { Controller, Get } from "@nestjs/common";
 import { AppService } from "./app.service";
-import { autometricsDecorator as autometrics } from "autometrics";
+import { autometricsMethodDecorator as autometrics } from "autometrics";
 
 @Controller()
 export class AppController {

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -13,7 +13,7 @@
     "start:prod": "node dist/main"
   },
   "dependencies": {
-    "@autometrics/autometrics": "^0.1.1",
+    "@autometrics/autometrics": "file:../../packages/autometrics-lib",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
@@ -21,7 +21,7 @@
     "rxjs": "^7.2.0"
   },
   "devDependencies": {
-    "@autometrics/typescript-plugin": "^0.1.1",
+    "@autometrics/typescript-plugin": "file:../../packages/autometrics-typescript-plugin",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",

--- a/examples/nestjs/src/app.service.ts
+++ b/examples/nestjs/src/app.service.ts
@@ -1,4 +1,4 @@
-import { autometricsDecorator as autometrics } from '@autometrics/autometrics';
+import { autometricsMethodDecorator as autometrics } from '@autometrics/autometrics';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/examples/nestjs/src/app.service.ts
+++ b/examples/nestjs/src/app.service.ts
@@ -1,9 +1,9 @@
-import { autometricsMethodDecorator as autometrics } from '@autometrics/autometrics';
+import { Autometrics } from '@autometrics/autometrics';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
+@Autometrics()
 export class AppService {
-  @autometrics
   getHello(): string {
     return 'Hello World!';
   }

--- a/packages/autometrics-lib/src/utils.ts
+++ b/packages/autometrics-lib/src/utils.ts
@@ -1,0 +1,86 @@
+import { autometrics, AutometricsOptions } from "./wrappers";
+
+export function getAutometricsMethodDecorator(
+  autometricsOptions?: AutometricsOptions,
+) {
+  return function (
+    _target: Object,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalFunction = descriptor.value;
+    descriptor.value = autometrics(autometricsOptions, originalFunction);
+
+    return descriptor;
+  };
+}
+
+export function getAutometricsClassDecorator(
+  autometricsOptions?: AutometricsOptions,
+) {
+  return function (classConstructor: Function) {
+    const prototype = classConstructor.prototype;
+    const properties = Object.getOwnPropertyNames(prototype);
+
+    for (const key of properties) {
+      const property = prototype[key];
+
+      if (typeof property === "function" && key !== "constructor") {
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+
+        if (descriptor) {
+          const methodDecorator =
+            getAutometricsMethodDecorator(autometricsOptions);
+          const instrumentedDescriptor = methodDecorator({}, key, descriptor);
+
+          Object.defineProperty(prototype, key, instrumentedDescriptor);
+        }
+      }
+    }
+  };
+}
+
+// HACK: this entire function is a hacky way to acquire the module name for a
+// given function e.g.: dist/index.js
+export function getModulePath(): string | undefined {
+  Error.stackTraceLimit = 5;
+  const stack = new Error()?.stack?.split("\n");
+
+  let rootDir: string;
+
+  if (typeof process === "object") {
+    // HACK: this assumes the entire app was run from the root directory of the
+    // project
+    rootDir = process.cwd();
+    //@ts-ignore
+  } else if (typeof Deno === "object") {
+    //@ts-ignore
+    rootDir = Deno.cwd();
+  } else {
+    rootDir = "";
+  }
+
+  if (!stack) {
+    return;
+  }
+
+  /**
+   *
+   * 0: Error
+   * 1: at getModulePath() ...
+   * 2: at autometrics() ...
+   * 3: at ... -> 4th line is always the original caller
+   */
+  const originalCaller = 3 as const;
+
+  // The last element in this array will have the full path
+  const fullPath = stack[originalCaller].split(" ").pop();
+
+  // We split away everything up to the root directory of the project
+  let modulePath = fullPath.replace(rootDir, "");
+
+  // We split away the line and column numbers index.js:14:6
+  modulePath = modulePath.substring(0, modulePath.indexOf(":"));
+
+  return modulePath;
+}

--- a/packages/autometrics-lib/src/utils.ts
+++ b/packages/autometrics-lib/src/utils.ts
@@ -20,22 +20,31 @@ export function getAutometricsClassDecorator(
 ) {
   return function (classConstructor: Function) {
     const prototype = classConstructor.prototype;
-    const properties = Object.getOwnPropertyNames(prototype);
+    const propertyNames = Object.getOwnPropertyNames(prototype);
 
-    for (const key of properties) {
-      const property = prototype[key];
+    for (const propertyName of propertyNames) {
+      const property = prototype[propertyName];
 
-      if (typeof property === "function" && key !== "constructor") {
-        const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
-
-        if (descriptor) {
-          const methodDecorator =
-            getAutometricsMethodDecorator(autometricsOptions);
-          const instrumentedDescriptor = methodDecorator({}, key, descriptor);
-
-          Object.defineProperty(prototype, key, instrumentedDescriptor);
-        }
+      if (typeof property !== "function" || propertyName === "constructor") {
+        continue;
       }
+
+      const descriptor = Object.getOwnPropertyDescriptor(
+        prototype,
+        propertyName,
+      );
+      if (!descriptor) {
+        continue;
+      }
+
+      const methodDecorator = getAutometricsMethodDecorator(autometricsOptions);
+      const instrumentedDescriptor = methodDecorator(
+        {},
+        propertyName,
+        descriptor,
+      );
+
+      Object.defineProperty(prototype, propertyName, instrumentedDescriptor);
     }
   };
 }

--- a/packages/autometrics-lib/src/utils.ts
+++ b/packages/autometrics-lib/src/utils.ts
@@ -1,5 +1,10 @@
 import { autometrics, AutometricsOptions } from "./wrappers";
 
+/**
+ * Decorator factory that returns a method decorator. Optionally accepts
+ * an autometrics options object.
+ * @param autometricsOptions
+ */
 export function getAutometricsMethodDecorator(
   autometricsOptions?: AutometricsOptions,
 ) {
@@ -15,6 +20,12 @@ export function getAutometricsMethodDecorator(
   };
 }
 
+/**
+ * Decorator factory that returns a class decorator that instruments all methods
+ * of a class with autometrics. Optionally accepts an autometrics options
+ * object.
+ * @param autometricsOptions
+ */
 export function getAutometricsClassDecorator(
   autometricsOptions?: AutometricsOptions,
 ) {
@@ -92,4 +103,14 @@ export function getModulePath(): string | undefined {
   modulePath = modulePath.substring(0, modulePath.indexOf(":"));
 
   return modulePath;
+}
+
+export function isPromise<T extends Promise<void>>(val: unknown): val is T {
+  return (
+    typeof val === "object" &&
+    "then" in val &&
+    typeof val.then === "function" &&
+    "catch" in val &&
+    typeof val.catch === "function"
+  );
 }

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -45,6 +45,32 @@ export function autometricsDecorator(
       throw error;
     }
   };
+
+  return descriptor;
+}
+
+// TODO: write JSdoc
+export function autometricsClassDecorator(classConstructor: Function) {
+  const prototype = classConstructor.prototype;
+  const properties = Object.getOwnPropertyNames(prototype);
+
+  for (const key of properties) {
+    const property = prototype[key];
+
+    if (typeof property === "function" && key !== "constructor") {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+
+      if (descriptor) {
+        const instrumentedDescriptor = autometricsDecorator(
+          {},
+          key,
+          descriptor,
+        );
+
+        Object.defineProperty(prototype, key, instrumentedDescriptor);
+      }
+    }
+  }
 }
 
 // Function Wrapper

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -217,6 +217,19 @@ export function autometrics<F extends FunctionSig>(
  * the decorator.
  * @param autometricsOptions
  * @example
+ * <caption>Basic class decorator implementation</caption>
+ * ```
+ *  \@Autometrics()
+ *  class Foo {
+ *   // Don't add a backslash in front of the decorator, this is only here to
+ *   // prevent the example from rendering incorrectly
+ *   bar() {
+ *     console.log("bar");
+ *   }
+ * }
+ * ```
+ * @example
+ * <caption>Method decorator that passes in an autometrics options object including SLO</caption>
  * ```typescript
  * import {
  *   Autometrics,
@@ -234,12 +247,13 @@ export function autometrics<F extends FunctionSig>(
  *
  * const autometricsOptions: AutometricsOptions = {
  *   functionName: "FooBar",
- *   moduleName: "FooModule",
  *   objective,
  *   trackConcurrency: true,
  * };
  *
  * class Foo {
+ *   // Don't add a backslash in front of the decorator, this is only here to
+ *   // prevent the example from rendering incorrectly
  *   \@Autometrics(autometricsOptions)
  *   bar() {
  *     console.log("bar");

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -3,16 +3,34 @@ import { Attributes } from "@opentelemetry/api";
 import type { Objective } from "./objectives";
 import { getMeter } from "./instrumentation";
 
+// WIP (Oscar)
+export function Autometrics(autometricsOptions?: AutometricsOptions) {
+  return function (
+    target: Function | Object,
+    propertyKey?: string,
+    descriptor?: PropertyDescriptor,
+  ) {
+    if (typeof target === "function") {
+      autometricsClassDecorator(autometricsOptions)(target);
+    }
+
+    autometricsMethodDecorator(autometricsOptions)(
+      target,
+      propertyKey,
+      descriptor,
+    );
+  };
+}
+
 /**
  * Autometrics decorator for **class methods** that automatically instruments
  * the decorated method with OpenTelemetry-compatible metrics.
  *
  * Hover over the method to get the links for generated queries (if you have the
  * language service plugin installed)
+ * @param autometricsOptions
  */
-export function autometricsMethodDecorator(
-  autometricsOptions?: AutometricsOptions,
-) {
+function autometricsMethodDecorator(autometricsOptions?: AutometricsOptions) {
   return function (
     _target: Object,
     _propertyKey: string,
@@ -32,9 +50,8 @@ export function autometricsMethodDecorator(
  * Hover over the method to get the links for generated queries (if you have the
  * language service plugin installed)
  * @param autometricsOptions
- * @returns
  */
-export function autometricsClassDecorator(
+function autometricsClassDecorator(
   autometricsOptions?: Omit<AutometricsOptions, "functionName">,
 ) {
   return function (classConstructor: Function) {

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -24,27 +24,29 @@ export function autometricsDecorator(autometricsOptions?: AutometricsOptions) {
 }
 
 // TODO: write JSdoc
-export function autometricsClassDecorator(classConstructor: Function) {
-  const prototype = classConstructor.prototype;
-  const properties = Object.getOwnPropertyNames(prototype);
+export function autometricsClassDecorator(
+  autometricsOptions?: Omit<AutometricsOptions, "functionName">,
+) {
+  return function (classConstructor: Function) {
+    const prototype = classConstructor.prototype;
+    const properties = Object.getOwnPropertyNames(prototype);
 
-  for (const key of properties) {
-    const property = prototype[key];
+    for (const key of properties) {
+      const property = prototype[key];
 
-    if (typeof property === "function" && key !== "constructor") {
-      const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+      if (typeof property === "function" && key !== "constructor") {
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
 
-      if (descriptor) {
-        const instrumentedDescriptor = autometricsDecorator()(
-          {},
-          key,
-          descriptor,
-        );
+        if (descriptor) {
+          const instrumentedDescriptor = autometricsDecorator(
+            autometricsOptions,
+          )({}, key, descriptor);
 
-        Object.defineProperty(prototype, key, instrumentedDescriptor);
+          Object.defineProperty(prototype, key, instrumentedDescriptor);
+        }
       }
     }
-  }
+  };
 }
 
 // Function Wrapper

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -47,6 +47,19 @@ export function isAutometricsWrappedOrDecorated(
     return hasAutometricsDecorator;
   }
 
+  // WIP (Oscar): check if the decorator is added to the class itself
+  if (
+    ts.isClassDeclaration(node.parent.parent) &&
+    ts.getDecorators(node.parent.parent)
+  ) {
+    const decorators = ts.getDecorators(node.parent.parent);
+    const hasAutometricsDecorator = decorators.some((decorator) =>
+      decorator.getText().startsWith("@autometrics"),
+    );
+
+    return hasAutometricsDecorator;
+  }
+
   // Otherwise just return false
   return false;
 }

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -42,29 +42,18 @@ export function isAutometricsWrappedOrDecorated(
     .getSymbolAtLocation(node)
     .declarations.find((declaration) => ts.isMethodDeclaration(declaration));
 
-  // Class method
-  if (ts.canHaveDecorators(method) && ts.getDecorators(method)) {
-    const isDecorated = hasAutometricsDecorator(method);
-    return isDecorated;
-  }
-
-  // Class
-  if (ts.isClassDeclaration(method.parent) && ts.getDecorators(method.parent)) {
-    const isDecorated = hasAutometricsDecorator(method.parent);
-    return isDecorated;
-  }
-
-  // Otherwise just return false
-  return false;
+  const isDecorated =
+    hasAutometricsDecorator(method) || hasAutometricsDecorator(method.parent);
+  return isDecorated;
 }
 
 // TODO (Oscar): write JSDoc
 function hasAutometricsDecorator(node: ts.Node) {
-  if (!ts.canHaveDecorators(node)) {
+  const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
+  if (!decorators) {
     return false;
   }
 
-  const decorators = ts.getDecorators(node);
   const hasAutometricsDecorator = decorators.some((decorator) =>
     decorator.getText().startsWith("@autometrics"),
   );

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -1,6 +1,7 @@
 import ts from "typescript/lib/tsserverlibrary";
 
 import type { NodeType } from "./types";
+import { hasAutometricsDecorator } from "./utils";
 
 /**
  * Checks if the node is wrapped or decorated by Autometrics (but not the
@@ -45,20 +46,6 @@ export function isAutometricsWrappedOrDecorated(
   const isDecorated =
     hasAutometricsDecorator(method) || hasAutometricsDecorator(method.parent);
   return isDecorated;
-}
-
-// TODO (Oscar): write JSDoc
-function hasAutometricsDecorator(node: ts.Node) {
-  const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
-  if (!decorators) {
-    return false;
-  }
-
-  const hasAutometricsDecorator = decorators.some((decorator) =>
-    decorator.getText().startsWith("@autometrics"),
-  );
-
-  return hasAutometricsDecorator;
 }
 
 /**

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -38,7 +38,7 @@ export function isAutometricsWrappedOrDecorated(
   }
 
   // If none of the function checkers return, we continue investigating if a
-  // decorator is applied to either a class method or class itself
+  // decorator is applied to either a class method or its parent class
   const method = typechecker
     .getSymbolAtLocation(node)
     .declarations.find((declaration) => ts.isMethodDeclaration(declaration));

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -1,7 +1,6 @@
 import ts from "typescript/lib/tsserverlibrary";
 
 import type { NodeType } from "./types";
-import { hasAutometricsDecorator } from "./utils";
 
 /**
  * Checks if the node is wrapped or decorated by Autometrics (but not the
@@ -49,6 +48,19 @@ export function isAutometricsWrappedOrDecorated(
   const isDecorated =
     hasAutometricsDecorator(method) || hasAutometricsDecorator(method.parent);
   return isDecorated;
+}
+
+export function hasAutometricsDecorator(node: ts.Node) {
+  const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
+  if (!decorators) {
+    return false;
+  }
+
+  const hasAutometricsDecorator = decorators.some((decorator) =>
+    decorator.getText().startsWith("@Autometrics"),
+  );
+
+  return hasAutometricsDecorator;
 }
 
 /**

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -42,6 +42,9 @@ export function isAutometricsWrappedOrDecorated(
   const method = typechecker
     .getSymbolAtLocation(node)
     .declarations.find((declaration) => ts.isMethodDeclaration(declaration));
+  if (!method) {
+    return false;
+  }
 
   const isDecorated =
     hasAutometricsDecorator(method) || hasAutometricsDecorator(method.parent);

--- a/packages/autometrics-typescript-plugin/src/astHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/astHelpers.ts
@@ -36,6 +36,9 @@ export function isAutometricsWrappedOrDecorated(
     return true;
   }
 
+  // TODO (Oscar): refactor logic that determines if a class or method is
+  // decorated
+
   // If none of the function checkers return, we continue investigating if it
   // has the right decorators for class methods
   if (ts.canHaveDecorators(node.parent) && ts.getDecorators(node.parent)) {
@@ -47,12 +50,32 @@ export function isAutometricsWrappedOrDecorated(
     return hasAutometricsDecorator;
   }
 
-  // WIP (Oscar): check if the decorator is added to the class itself
+  // WIP (Oscar): check if the autometrics decorator is added to the class
+  // itself
   if (
     ts.isClassDeclaration(node.parent.parent) &&
+    ts.canHaveDecorators(node.parent.parent) &&
     ts.getDecorators(node.parent.parent)
   ) {
     const decorators = ts.getDecorators(node.parent.parent);
+    const hasAutometricsDecorator = decorators.some((decorator) =>
+      decorator.getText().startsWith("@autometrics"),
+    );
+
+    return hasAutometricsDecorator;
+  }
+
+  // WIP (Oscar): check if the called method is part of a class that has the
+  // autometrics decorator applied
+  const method = typechecker
+    .getSymbolAtLocation(node)
+    .declarations.find((d) => ts.isMethodDeclaration(d));
+  if (
+    ts.isClassDeclaration(method.parent) &&
+    ts.canHaveDecorators(method.parent) &&
+    ts.getDecorators(method.parent)
+  ) {
+    const decorators = ts.getDecorators(method.parent);
     const hasAutometricsDecorator = decorators.some((decorator) =>
       decorator.getText().startsWith("@autometrics"),
     );

--- a/packages/autometrics-typescript-plugin/src/utils.ts
+++ b/packages/autometrics-typescript-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import ts from "typescript/lib/tsserverlibrary";
+import type ts from "typescript/lib/tsserverlibrary";
 
 const PLUGIN_NAME = "Autometrics TypeScript Plugin";
 
@@ -20,4 +20,3 @@ export function createLogger(project: ts.server.Project) {
     project.projectService.logger.info(`${PLUGIN_NAME}: ${msg}`);
   };
 }
-

--- a/packages/autometrics-typescript-plugin/src/utils.ts
+++ b/packages/autometrics-typescript-plugin/src/utils.ts
@@ -31,7 +31,7 @@ export function hasAutometricsDecorator(node: ts.Node) {
   }
 
   const hasAutometricsDecorator = decorators.some((decorator) =>
-    decorator.getText().startsWith("@autometrics"),
+    decorator.getText().startsWith("@Autometrics"),
   );
 
   return hasAutometricsDecorator;

--- a/packages/autometrics-typescript-plugin/src/utils.ts
+++ b/packages/autometrics-typescript-plugin/src/utils.ts
@@ -21,15 +21,3 @@ export function createLogger(project: ts.server.Project) {
   };
 }
 
-export function hasAutometricsDecorator(node: ts.Node) {
-  const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
-  if (!decorators) {
-    return false;
-  }
-
-  const hasAutometricsDecorator = decorators.some((decorator) =>
-    decorator.getText().startsWith("@Autometrics"),
-  );
-
-  return hasAutometricsDecorator;
-}

--- a/packages/autometrics-typescript-plugin/src/utils.ts
+++ b/packages/autometrics-typescript-plugin/src/utils.ts
@@ -21,9 +21,6 @@ export function createLogger(project: ts.server.Project) {
   };
 }
 
-/**
- * Helper function that checks if a node has an autometrics decorator
- */
 export function hasAutometricsDecorator(node: ts.Node) {
   const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
   if (!decorators) {

--- a/packages/autometrics-typescript-plugin/src/utils.ts
+++ b/packages/autometrics-typescript-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import type ts from "typescript/lib/tsserverlibrary";
+import ts from "typescript/lib/tsserverlibrary";
 
 const PLUGIN_NAME = "Autometrics TypeScript Plugin";
 
@@ -19,4 +19,20 @@ export function createLogger(project: ts.server.Project) {
   return (msg: string) => {
     project.projectService.logger.info(`${PLUGIN_NAME}: ${msg}`);
   };
+}
+
+/**
+ * Helper function that checks if a node has an autometrics decorator
+ */
+export function hasAutometricsDecorator(node: ts.Node) {
+  const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
+  if (!decorators) {
+    return false;
+  }
+
+  const hasAutometricsDecorator = decorators.some((decorator) =>
+    decorator.getText().startsWith("@autometrics"),
+  );
+
+  return hasAutometricsDecorator;
 }


### PR DESCRIPTION
Introduces an `@Autometrics()` decorator that can be applied to both a class or class method.

- Instruments all methods defined in a class when applied to a class;
- Decorator accepts an `AutometricsOptions` object like the general function wrapper;
- Update README & NestJS examples;
- Update the TypeScript plugin displaying the instrumented methods when hovering;
- Move helper logic to `utils.ts` in both the TypeScript plugin & general autometrics libs;
- Add breaks at 80-character limit where possible in files I've been working in.

Current known issues (to be picked up after this PR):
- The decorator accepts the `AutometricsOptions` object, including its `functionName` property. This should be prevented when decorating a class as it often has multiple methods - which will be interpreted with the same name by autometrics.

Resolves https://github.com/autometrics-dev/autometrics-ts/issues/4

---
Consider this code example:
```typescript
import { Autometrics } from "autometrics";

@Autometrics()
class Foo {
  bar() {
    console.log("fooBar");
  }
}

const foo = new Foo();
foo.bar();
```

Which'll result in instrumented functions with TypeScript annotations:
<img width="466" alt="class_method" src="https://github.com/autometrics-dev/autometrics-ts/assets/33732524/8ed66293-d786-4bcd-a048-aa73972c9edc">
<img width="466" alt="method_instance" src="https://github.com/autometrics-dev/autometrics-ts/assets/33732524/05ad1f48-c0e8-4bac-b86b-629815b9cf66">

