### PR TITLE
Add build_info data

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,12 @@ The Autometrics library:
 - Uses a Prometheus Exporter to write metrics to a `/metrics` endpoint (by
   default on port `:9464`) or pushes them to a specified gateway (if used in
   browser)
-- Uses a TypeScript plugin to automatically add useful Prometheus queries in the doc comments for instrumented functions
+- Uses a TypeScript plugin / VSCode extension to automatically add useful Prometheus queries in the doc comments for instrumented functions
 
 ## Quickstart
 
 ```shell
 npm install --save autometrics
-npm install --save-dev @autometrics/typescript-plugin
-```
-
-Enable the TypeScript plugin by adding it to `tsconfig.json`:
-
-```json
-{
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "@autometrics/typescript-plugin",
-        "prometheusUrl": ""
-      }
-    ]
-  }
-}
 ```
 
 Use the library in your code:
@@ -98,10 +82,27 @@ The default `autometrics` package bundles `@opentelemetry/sdk-metrics` and
 these in your codebase or want to use other custom metrics, use the following
 installation option.
 
-Install the wrappers and the language service plugin:
+Install the wrappers:
 
 ```shell
 npm install --save @autometrics/autometrics
+```
+
+Import and use the library in your code:
+
+```typescript
+import { autometrics } from "@autometrics/autometrics"
+```
+
+## Getting PromQL queries
+
+In order to get PromQL query links in your IDE download the [Autometrics VSCode
+extension](https://marketplace.visualstudio.com/items?itemName=Fiberplane.autometrics).
+
+If you're on any other IDE you can install and add the TypeScript plugin
+directly:
+
+```bash
 npm install --save-dev @autometrics/typescript-plugin
 ```
 
@@ -124,6 +125,15 @@ Add the language service plugin to the `tsconfig.json` file:
 
 Autometrics provides [Grafana dashboards](https://github.com/autometrics-dev/autometrics-shared#dashboards) that will work for any project instrumented with the library.
 
+## Identifying commits that introduce errors
+
+Autometrics makes it easy to [spot versions and commits that introduce errors or latency](https://fiberplane.com/blog/autometrics-rs-0-4-spot-commits-that-introduce-errors-or-slow-down-your-application).
+
+| Label | Run-Time Environment Variables | Default value |
+|---|---|---|
+| `version` | `AUTOMETRICS_VERSION` or `PACKAGE_VERSION` | `npm_package_version` (set by npm/yarn/pnpm by default) |
+| `commit` | `AUTOMETRICS_COMMIT` or `COMMIT_SHA` | `""` |
+| `branch` | `AUTOMETRICS_BRANCH` or `BRANCH_NAME` | `""` |
 
 ## Alerts / SLOs
 

--- a/packages/autometrics-lib/src/buildInfo.ts
+++ b/packages/autometrics-lib/src/buildInfo.ts
@@ -27,14 +27,14 @@ function getVersion() {
   if (process.env.npm_package_version) {
     return process.env.npm_package_version;
   } else {
-    return process.env.PACKAGE_VERSION;
+    return process.env.PACKAGE_VERSION || process.env.AUTOMETRICS_VERSION;
   }
 }
 
 function getCommit() {
-  return process.env.COMMIT_SHA;
+  return process.env.COMMIT_SHA || process.env.AUTOMETRICS_COMMIT;
 }
 
 function getBranch() {
-  return process.env.BRANCH_NAME;
+  return process.env.BRANCH_NAME || process.env.AUTOMETRICS_BRANCH;
 }

--- a/packages/autometrics-lib/src/buildInfo.ts
+++ b/packages/autometrics-lib/src/buildInfo.ts
@@ -11,24 +11,24 @@ let buildInfo: BuildInfo | undefined;
 export function registerBuildInfo() {
   if (buildInfo) {
     return;
-  } else {
-    buildInfo = {
-      version: getVersion(),
-      commit: getCommit(),
-      branch: getBranch(),
-    };
-
-    const gauge = getMeter().createUpDownCounter("build_info");
-    gauge.add(1, buildInfo);
   }
+
+  buildInfo = {
+    version: getVersion(),
+    commit: getCommit(),
+    branch: getBranch(),
+  };
+
+  const gauge = getMeter().createUpDownCounter("build_info");
+  gauge.add(1, buildInfo);
 }
 
 function getVersion() {
   if (process.env.npm_package_version) {
     return process.env.npm_package_version;
-  } else {
-    return process.env.PACKAGE_VERSION || process.env.AUTOMETRICS_VERSION;
   }
+
+  return process.env.PACKAGE_VERSION || process.env.AUTOMETRICS_VERSION;
 }
 
 function getCommit() {

--- a/packages/autometrics-lib/src/buildInfo.ts
+++ b/packages/autometrics-lib/src/buildInfo.ts
@@ -1,0 +1,40 @@
+import { getMeter } from "./instrumentation";
+
+type BuildInfo = {
+  version?: string;
+  commit?: string;
+  branch?: string;
+};
+
+let buildInfo: BuildInfo | undefined;
+
+export function registerBuildInfo() {
+  if (buildInfo) {
+    return;
+  } else {
+    buildInfo = {
+      version: getVersion(),
+      commit: getCommit(),
+      branch: getBranch(),
+    };
+
+    const gauge = getMeter().createUpDownCounter("build_info");
+    gauge.add(1, buildInfo);
+  }
+}
+
+function getVersion() {
+  if (process.env.npm_package_version) {
+    return process.env.npm_package_version;
+  } else {
+    return process.env.PACKAGE_VERSION;
+  }
+}
+
+function getCommit() {
+  return process.env.COMMIT_SHA;
+}
+
+function getBranch() {
+  return process.env.BRANCH_NAME;
+}

--- a/packages/autometrics-lib/src/instrumentation.ts
+++ b/packages/autometrics-lib/src/instrumentation.ts
@@ -3,6 +3,7 @@ import {
   PrometheusSerializer,
 } from "@opentelemetry/exporter-prometheus";
 import {
+  AggregationTemporality,
   InMemoryMetricExporter,
   MeterProvider,
   MetricReader,
@@ -43,7 +44,7 @@ export function init(options: initOptions) {
     exporter = new PeriodicExportingMetricReader({
       // 0 - using delta aggregation temporality setting
       // to ensure data submitted to the gateway is accurate
-      exporter: new InMemoryMetricExporter(0),
+      exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
     });
     // Make sure the provider is initialized and exporter is registered
     getMetricsProvider();

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -8,6 +8,7 @@ import {
   getModulePath,
   isPromise,
 } from "./utils";
+import { registerBuildInfo } from "./buildInfo";
 
 // Function Wrapper
 // This seems to be the preferred way for defining functions in TypeScript
@@ -125,6 +126,7 @@ export function autometrics<F extends FunctionSig>(
 
   return function (...params) {
     const meter = getMeter();
+    registerBuildInfo();
     const autometricsStart = performance.now();
     const counter = meter.createCounter("function.calls.count");
     const histogram = meter.createHistogram("function.calls.duration");

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -97,9 +97,10 @@ export function autometrics<F extends FunctionSig>(
   }
 
   if (!functionName) {
-    throw new Error(
-      "Autometrics decorated function must have a name to successfully create a metric",
+    console.trace(
+      "Autometrics decorated function must have a name to successfully create a metric. Function will not be instrumented.",
     );
+    return fn;
   }
 
   const counterObjectiveAttributes: Attributes = {};

--- a/packages/autometrics-lib/tests/integration.test.ts
+++ b/packages/autometrics-lib/tests/integration.test.ts
@@ -1,6 +1,7 @@
 import { autometrics, init } from "../src";
 import { describe, test, expect, beforeAll, afterEach } from "vitest";
 import {
+  AggregationTemporality,
   InMemoryMetricExporter,
   PeriodicExportingMetricReader,
 } from "@opentelemetry/sdk-metrics";
@@ -14,7 +15,7 @@ describe("Autometrics integration test", () => {
     exporter = new PeriodicExportingMetricReader({
       // 0 - using delta aggregation temporality setting
       // to ensure data submitted to the gateway is accurate
-      exporter: new InMemoryMetricExporter(0),
+      exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
     });
 
     init({ exporter });

--- a/packages/autometrics-typescript-plugin/src/index.ts
+++ b/packages/autometrics-typescript-plugin/src/index.ts
@@ -67,9 +67,9 @@ function init(modules: { typescript: typeof tsserver }) {
         typechecker,
       );
 
-      const requestRate = createRequestRateQuery(nodeIdentifier, nodeType);
-      const errorRatio = createErrorRatioQuery(nodeIdentifier, nodeType);
-      const latency = createLatencyQuery(nodeIdentifier, nodeType);
+      const requestRate = createRequestRateQuery(nodeIdentifier);
+      const errorRatio = createErrorRatioQuery(nodeIdentifier);
+      const latency = createLatencyQuery(nodeIdentifier);
 
       const requestRateUrl = makePrometheusUrl(requestRate, prometheusBase);
       const errorRatioUrl = makePrometheusUrl(errorRatio, prometheusBase);

--- a/packages/autometrics-typescript-plugin/src/queryHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/queryHelpers.ts
@@ -8,15 +8,11 @@ export function createLatencyQuery(nodeIdentifier: string) {
   return `histogram_quantile(0.99, ${latency}) or histogram_quantile(0.95, ${latency})`;
 }
 
-export function createRequestRateQuery(
-  nodeIdentifier: string,
-) {
+export function createRequestRateQuery(nodeIdentifier: string) {
   return `sum by (function, module, commit, version) (rate(function_calls_count_total{function="${nodeIdentifier}"}[5m]) ${BUILD_INFO_LABELS})`;
 }
 
-export function createErrorRatioQuery(
-  nodeIdentifier: string,
-) {
+export function createErrorRatioQuery(nodeIdentifier: string) {
   const requestQuery = createRequestRateQuery(nodeIdentifier);
   return `sum by (function, module, commit, version) (rate(function_calls_count_total{function="${nodeIdentifier}",result="error"}[5m]) ${BUILD_INFO_LABELS}) / ${requestQuery}`;
 }

--- a/packages/autometrics-typescript-plugin/src/queryHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/queryHelpers.ts
@@ -5,7 +5,7 @@ const BUILD_INFO_LABELS =
 
 export function createLatencyQuery(nodeIdentifier: string) {
   const latency = `sum by (le, function, module, commit, version) (rate(function_calls_duration_bucket{function="${nodeIdentifier}"}[5m]) ${BUILD_INFO_LABELS})`;
-  return `histogram_quantile(0.99, ${latency}) or histogram_quantile(0.95, ${latency})`;
+  return `histogram_quantile(0.99, ${latency}, \"percentile_latency\", \"99\", \"\",\"\") or histogram_quantile(0.95, ${latency}), \"percentile_latency\", \"95\", \"\", \"\")`;
 }
 
 export function createRequestRateQuery(nodeIdentifier: string) {

--- a/packages/autometrics-typescript-plugin/src/queryHelpers.ts
+++ b/packages/autometrics-typescript-plugin/src/queryHelpers.ts
@@ -1,6 +1,5 @@
 /* Functions below template creation of relevant queries and encode them in URL */
 
-import type { NodeType } from "./types";
 const BUILD_INFO_LABELS =
   "* on (instance, job) group_left(version, commit) (last_over_time(build_info[1s]) or on (instance, job) up)";
 


### PR DESCRIPTION
Resolves #45 

This update adds `build_info` data to the metrics exported. Whenever the first
`autometrics` wrapper is called it will create an object that will persisting
through the runtime and report version, commit, and branch data (depending on
what is supplied). The data can be supplied through env variables:

version: picked up automatically if the package is run through `npm`, `yarn`, or
`pnpm`, - can be manually supplied through `PACKAGE_VERSION` or `AUTOMETRICS_VERSION` otherwise.

commit: must be supplied through `COMMIT_SHA` or `AUTOMETRICS_COMMIT` env variable

branch: must be supplied through `BRANCH_NAME` or `AUTOMETRICS_BRANCH` env variable

The update also fixes a previous functionality that would throw an error if a
function without a name was supplied. It will now just log a warning and returns the
function early without attempting to instrument.

- replace error throw with a log
- add a way to register build_info data to the metrics
