### PR TITLE
Improve `@Autometrics()` decorator type signature

### DIFF
--- a/packages/autometrics-lib/src/utils.ts
+++ b/packages/autometrics-lib/src/utils.ts
@@ -1,4 +1,8 @@
-import { autometrics, AutometricsOptions } from "./wrappers";
+import {
+  autometrics,
+  AutometricsClassDecoratorOptions,
+  AutometricsOptions,
+} from "./wrappers";
 
 /**
  * Decorator factory that returns a method decorator. Optionally accepts
@@ -27,7 +31,7 @@ export function getAutometricsMethodDecorator(
  * @param autometricsOptions
  */
 export function getAutometricsClassDecorator(
-  autometricsOptions?: AutometricsOptions,
+  autometricsOptions?: AutometricsClassDecoratorOptions,
 ) {
   return function (classConstructor: Function) {
     const prototype = classConstructor.prototype;

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -207,6 +207,15 @@ export function autometrics<F extends FunctionSig>(
   };
 }
 
+type AutometricsClassDecoratorOptions = Omit<
+  AutometricsOptions,
+  "functionName"
+>;
+
+type AutometricsDecoratorOptions<T> = T extends Function
+  ? AutometricsClassDecoratorOptions
+  : AutometricsOptions;
+
 /**
  * Autometrics decorator that can be applied to either a class or class method
  * that automatically instruments methods with OpenTelemetry-compatible metrics.
@@ -261,9 +270,17 @@ export function autometrics<F extends FunctionSig>(
  * }
  * ```
  */
-export function Autometrics(autometricsOptions?: AutometricsOptions) {
-  return function (
-    target: Function | Object,
+export function Autometrics<T extends Function | Object>(
+  autometricsOptions?: AutometricsDecoratorOptions<T>,
+) {
+  function decorator<T extends Function>(target: T): void;
+  function decorator<T extends Object>(
+    target: T,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ): void;
+  function decorator<T>(
+    target: T,
     propertyKey?: string,
     descriptor?: PropertyDescriptor,
   ) {
@@ -276,5 +293,7 @@ export function Autometrics(autometricsOptions?: AutometricsOptions) {
 
     const methodDecorator = getAutometricsMethodDecorator(autometricsOptions);
     methodDecorator(target, propertyKey, descriptor);
-  };
+  }
+
+  return decorator;
 }

--- a/packages/autometrics-lib/src/wrappers.ts
+++ b/packages/autometrics-lib/src/wrappers.ts
@@ -207,7 +207,7 @@ export function autometrics<F extends FunctionSig>(
   };
 }
 
-type AutometricsClassDecoratorOptions = Omit<
+export type AutometricsClassDecoratorOptions = Omit<
   AutometricsOptions,
   "functionName"
 >;


### PR DESCRIPTION
The decorator currently accepts an `AutometricsOptions` object, that includes the `functionName` property. When decorating a class we're now omitting this option as this property should only be set on single functions/methods.

```typescript
@Autometrics()
class Foo {
  bar() {}
}

class Bar {
  @Autometrics()
  baz() {}
}
```

![class](https://github.com/autometrics-dev/autometrics-ts/assets/33732524/62d81527-1af1-45d8-8c11-ad701a632075)
![method](https://github.com/autometrics-dev/autometrics-ts/assets/33732524/9ab026f6-d8e4-48b4-bfe5-b0da848297ef)
