### PR TITLE
Properly fix `build_info` and add a unit test

### DIFF
--- a/packages/lib/src/buildInfo.ts
+++ b/packages/lib/src/buildInfo.ts
@@ -14,8 +14,13 @@ export type BuildInfo = {
 
 export let buildInfo: BuildInfo = {};
 
-export function registerBuildInfo() {
-  if (buildInfo) {
+export function recordBuildInfo(buildInfo: BuildInfo) {
+  const gauge = getMeter().createUpDownCounter("build_info");
+  gauge.add(1, buildInfo);
+}
+
+export function setBuildInfo() {
+  if (Object.keys(buildInfo).length > 0) {
     return buildInfo;
   }
 
@@ -27,8 +32,7 @@ export function registerBuildInfo() {
     branch: getBranch(runtime),
   };
 
-  const gauge = getMeter().createUpDownCounter("build_info");
-  gauge.add(1, buildInfo);
+  recordBuildInfo(buildInfo);
 
   return buildInfo;
 }

--- a/packages/lib/src/instrumentation.ts
+++ b/packages/lib/src/instrumentation.ts
@@ -9,7 +9,7 @@ import {
   MetricReader,
   PeriodicExportingMetricReader,
 } from "@opentelemetry/sdk-metrics";
-import { buildInfo, BuildInfo } from "./buildInfo";
+import { buildInfo, BuildInfo, recordBuildInfo } from "./buildInfo";
 
 let autometricsMeterProvider: MeterProvider;
 let exporter: MetricReader;
@@ -49,6 +49,7 @@ export function init(options: initOptions) {
     buildInfo.version = options.buildInfo?.version;
     buildInfo.commit = options.buildInfo?.commit;
     buildInfo.branch = options.buildInfo?.branch;
+    recordBuildInfo(buildInfo);
   }
 
   logger("Using the user's Exporter configuration");

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -10,7 +10,7 @@ import {
   isObject,
   isPromise,
 } from "./utils";
-import { registerBuildInfo } from "./buildInfo";
+import { setBuildInfo } from "./buildInfo";
 
 let asyncLocalStorage: ALSInstance | undefined;
 if (typeof window === "undefined") {
@@ -181,7 +181,7 @@ export function autometrics<F extends FunctionSig>(
 
   return function (...params) {
     const meter = getMeter();
-    registerBuildInfo();
+    setBuildInfo();
     const autometricsStart = performance.now();
     const counter = meter.createCounter("function.calls.count");
     const histogram = meter.createHistogram("function.calls.duration");

--- a/packages/lib/tests/buildInfo.test.ts
+++ b/packages/lib/tests/buildInfo.test.ts
@@ -1,0 +1,38 @@
+import {
+  PeriodicExportingMetricReader,
+  InMemoryMetricExporter,
+  AggregationTemporality,
+} from "@opentelemetry/sdk-metrics";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { init } from "../src";
+
+let exporter: PeriodicExportingMetricReader;
+
+describe("Autometrics build info tests", () => {
+  beforeAll(async () => {
+    exporter = new PeriodicExportingMetricReader({
+      exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
+    });
+    init({ exporter });
+  });
+
+  afterEach(async () => {
+    await exporter.forceFlush();
+  });
+
+  test("build info is recorded", async () => {
+    const buildInfo = {
+      version: "1.0.0",
+      commit: "123456789",
+      branch: "main",
+    };
+    init({ buildInfo });
+
+    const buildInfoGauge = await exporter.collect();
+    const buildInfoGaugeData =
+      buildInfoGauge.resourceMetrics.scopeMetrics[0].metrics[0].dataPoints[0]
+        .attributes;
+
+    expect(buildInfoGaugeData).toEqual(buildInfo);
+  });
+});


### PR DESCRIPTION
- fix: actually make sure build_info gets properly recorded (previously it would read empty object)
- add buildinfo unit test
