### PR TITLE
Fix TS plugin errors

### DIFF
--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autometrics/typescript-plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Language service plugin for Autometrics",
   "author": "Fiberplane<info@fiberplane.com>",
   "contributors": [

--- a/packages/typescript-plugin/src/astHelpers.ts
+++ b/packages/typescript-plugin/src/astHelpers.ts
@@ -44,7 +44,7 @@ export function isAutometricsWrappedOrDecorated(
   // decorator is applied to either a class method or its parent class
   const method = typechecker
     .getSymbolAtLocation(node)
-    .declarations.find((declaration) => ts.isMethodDeclaration(declaration));
+    ?.declarations.find((declaration) => ts.isMethodDeclaration(declaration));
   if (!method) {
     return false;
   }
@@ -123,7 +123,7 @@ export function getNodeIdentifier(
 export function getNodeType(node: ts.Node, typechecker: ts.TypeChecker) {
   const declaration = typechecker.getSymbolAtLocation(node);
 
-  if (!(declaration.valueDeclaration && node.parent)) {
+  if (!declaration?.valueDeclaration || !node?.parent) {
     return;
   }
 
@@ -143,7 +143,7 @@ export function getNodeType(node: ts.Node, typechecker: ts.TypeChecker) {
   // const originalFunc = () => {}
   if (
     ts.isVariableDeclaration(valueDeclaration) &&
-    ts.isFunctionLike(valueDeclaration.initializer)
+    ts.isFunctionLike(valueDeclaration?.initializer)
   ) {
     return "function";
   }
@@ -152,8 +152,8 @@ export function getNodeType(node: ts.Node, typechecker: ts.TypeChecker) {
   // autometrics
   // const funcWithMetrics = autometrics(originalFunc);
   if (
-    ts.isVariableDeclaration(declaration.valueDeclaration) &&
-    ts.isCallExpression(declaration.valueDeclaration.initializer)
+    ts.isVariableDeclaration(declaration?.valueDeclaration) &&
+    ts.isCallExpression(declaration?.valueDeclaration?.initializer)
   ) {
     return "function";
   }

--- a/packages/typescript-plugin/src/astHelpers.ts
+++ b/packages/typescript-plugin/src/astHelpers.ts
@@ -26,6 +26,10 @@ export function isAutometricsWrappedOrDecorated(
   // AutometricsWrapper or is wrapped by a function that has a type
   // AutometricsWrapper
   const checkWrapperType = (node: ts.Node) => {
+    if (ts.isSourceFile(node)) {
+      return;
+    }
+
     return typechecker.getTypeAtLocation(node)?.symbol?.getEscapedName();
   };
 


### PR DESCRIPTION
This small PR fixes a few issues I ran into with the TS plugin that would crash the TypeScript Language Service.

- add runtime type guard for when passed in node is a SourceFileObject
- add optional chaining to fix issues where JS process would attempt accessing values that didn't exist
- bump fix version for release
