### PR TITLE
Add a configurable 'html-comment' mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- added `quickInfoMode` config parameter to the typescript plugin. This is for communicating autometrics information from typescript to the autometrics extension.
+
 ## [v0.5] - 2023-05-26
 
 ### Added

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -67,6 +67,10 @@ function init(modules: { typescript: typeof tsserver }) {
         typechecker,
       );
 
+      // This could also be called the 'vscode' mode since it's only
+      // really used by the vscode extension. The output of this plugin will
+      // be an html comment containing a the name of the function in a special format
+      // that the vscode extension can parse.
       if (quickInfoMode === "html-comment") {
         const preamble = {
           kind: "string",


### PR DESCRIPTION
For the output of the `getQuickInfoAtPosition`

This PR adds a `quickInfoMode` parameter which is used for the typescript
plugin to communicate information about the current decorated function.

The [autometrics vscode extension](https://github.com/autometrics-dev/vscode-autometrics)
injects this parameter/option to the typescript
server.