### PR TITLE
Initialize counters at zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added functionality to initialize metrics at 0, so instrumented functions can be registered.
 - Fixed an issue where decorators were changing `this` values for the methods they'd be wrapping, breaking them.
 - Improved how `getModulePath` utility works, passing stack trace as structured data, and making it more robust.
 

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -179,15 +179,23 @@ export function autometrics<F extends FunctionSig>(
     }
   }
 
-  return function (...params) {
-    const meter = getMeter();
-    setBuildInfo();
-    const autometricsStart = performance.now();
-    const counter = meter.createCounter("function.calls.count");
-    const histogram = meter.createHistogram("function.calls.duration");
-    const gauge = meter.createUpDownCounter("function.calls.concurrent");
-    const caller = getALSCaller(asyncLocalStorage);
+  const meter = getMeter();
+  setBuildInfo();
+  const counter = meter.createCounter("function.calls.count");
+  const histogram = meter.createHistogram("function.calls.duration");
+  const gauge = meter.createUpDownCounter("function.calls.concurrent");
+  const caller = getALSCaller(asyncLocalStorage);
 
+  counter.add(0, {
+    function: functionName,
+    module: moduleName,
+    result: "ok",
+    caller,
+    ...counterObjectiveAttributes,
+  });
+
+  return function (...params) {
+    const autometricsStart = performance.now();
     if (trackConcurrency) {
       gauge.add(1, {
         function: functionName,


### PR DESCRIPTION
> Related to discussion: https://github.com/orgs/autometrics-dev/discussions/21

This PR enables wrapped functions and decorators to initialize counters at 0.

This will allow tooling that connects to Prometheus to be able to tell which functions are being tracked, even if those functions haven't been called since adding Autometrics to the codebase.