### PR TITLE
Fix module getter utility

### DIFF
--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -40,8 +40,6 @@ export function getModulePath(): string | undefined {
     rootDir = "";
   }
 
-  console.log(stack);
-
   if (!stack) {
     return;
   }

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -56,7 +56,7 @@ export function getModulePath(): string | undefined {
   // The last element in this array will have the full path
   const fullPath = stack[originalCaller].split(" ").pop();
 
-  const containsFileProtocol = fullPath?.includes("file://");
+  const containsFileProtocol = fullPath.includes("file://");
 
   // We split away everything up to the root directory of the project,
   // if the path contains file:// we need to remove it

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -56,8 +56,14 @@ export function getModulePath(): string | undefined {
   // The last element in this array will have the full path
   const fullPath = stack[originalCaller].split(" ").pop();
 
-  // We split away everything up to the root directory of the project
-  let modulePath = fullPath.replace(`file://${rootDir}`, "");
+  const containsFileProtocol = fullPath?.includes("file://");
+
+  // We split away everything up to the root directory of the project,
+  // if the path contains file:// we need to remove it
+  let modulePath = fullPath.replace(
+    containsFileProtocol ? `file://${rootDir}` : rootDir,
+    "",
+  );
 
   // We split away the line and column numbers index.js:14:6
   modulePath = modulePath.substring(0, modulePath.indexOf(":"));
@@ -68,6 +74,7 @@ export function getModulePath(): string | undefined {
 type ALSContext = {
   caller?: string;
 };
+
 export type ALSInstance = Awaited<ReturnType<typeof getALSInstance>>;
 
 export async function getALSInstance() {

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -40,6 +40,8 @@ export function getModulePath(): string | undefined {
     rootDir = "";
   }
 
+  console.log(stack);
+
   if (!stack) {
     return;
   }
@@ -57,7 +59,7 @@ export function getModulePath(): string | undefined {
   const fullPath = stack[originalCaller].split(" ").pop();
 
   // We split away everything up to the root directory of the project
-  let modulePath = fullPath.replace(rootDir, "");
+  let modulePath = fullPath.replace(`file://${rootDir}`, "");
 
   // We split away the line and column numbers index.js:14:6
   modulePath = modulePath.substring(0, modulePath.indexOf(":"));

--- a/packages/lib/tests/utils.test.ts
+++ b/packages/lib/tests/utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { getModulePath } from "../src/utils";
+
+// the existing getModulePath function is a hack that parses the stack trace
+// as string and extracts the module path from it. This test is to ensure that
+// the function works as expected
+describe("getModulePath test", () => {
+  test("gets the correct module path for the original caller", () => {
+    const modulePath = getModulePath();
+    expect(modulePath).toBeDefined();
+    // the original caller in this case is the vitest test runner although normally
+    // it would be the file route from which the function call came
+    expect(modulePath).toBe("/node_modules/@vitest/runner/dist/index.js");
+  });
+});


### PR DESCRIPTION
The module getter utility that parses the stack trace was silently failing and returning "file" in all cases. This fixes it by correctly replacing `file://` prefix and adds a unit test for the function

- fix module getter to correctly replace the file:// prefix along with the rootDir
- add a unit test for the module getter
