### PR TITLE
Fix PromQL errors

### DIFF
--- a/examples/express/src/index.ts
+++ b/examples/express/src/index.ts
@@ -41,43 +41,32 @@ app.get("/async", autometrics(asyncRoute));
 app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 
 async function generateRandomTraffic() {
-  const http = await import("http");
   console.log("Generating random traffic");
 
   while (true) {
     const type = Math.floor(Math.random() * 3);
 
-    // sleep duration is between 10 and 50 ms
     const sleepDuration = Math.floor(Math.random() * 400 + 100);
-
-    console.log(`Sleeping for ${sleepDuration}ms`);
 
     switch (type) {
       case 0: {
-        console.log("GET /");
         await fetch("http://localhost:8080");
       }
 
       case 1: {
-        console.log("GET /async");
         await fetch("http://localhost:8080/async");
       }
 
       case 2: {
-        console.log("GET /bad");
         await fetch("http://localhost:8080/bad");
-      }
-
-      default: {
-        console.log("none");
       }
     }
 
-    sleep(sleepDuration);
+    delay(sleepDuration);
   }
 }
 
-const sleep = (ms: number) => {
+const delay = (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 

--- a/examples/express/src/index.ts
+++ b/examples/express/src/index.ts
@@ -5,21 +5,19 @@ const app = express();
 
 const port = 8080;
 
-const rootRoute = (req: express.Request, res: express.Response) => {
+function rootRoute(req: express.Request, res: express.Response) {
   console.log("Request made");
   return res.status(200).send("did not delay - success");
-};
+}
 
 function badRoute(req: express.Request, res: express.Response) {
   console.log("Bad route request made");
   throw new Error("Bad request");
 }
 
-const badRouteMetrics = autometrics(badRoute);
-
 async function asyncRoute(req: express.Request, res: express.Response) {
   console.log("Async route request made");
-  const result = await asyncCall(); // works with async
+  const result = await asyncCall();
   return res.status(200).send(result);
 }
 
@@ -31,45 +29,57 @@ function resolveAfterHalfSecond(): Promise<string> {
   });
 }
 
-async function asyncCall() {
+const asyncCall = autometrics(async function asyncCall() {
   console.log("Calling async function");
   return await resolveAfterHalfSecond();
-}
+});
 
 app.get("/", autometrics(rootRoute));
-app.get("/bad", (req, res) => badRouteMetrics(req, res));
+app.get("/bad", autometrics(badRoute));
 app.get("/async", autometrics(asyncRoute));
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 
 async function generateRandomTraffic() {
-  const loopTimes = Math.floor(Math.random() * 30 + 20);
   const http = await import("http");
+  console.log("Generating random traffic");
 
-  for (let i = 0; i < loopTimes; i++) {
+  while (true) {
     const type = Math.floor(Math.random() * 3);
+
+    // sleep duration is between 10 and 50 ms
+    const sleepDuration = Math.floor(Math.random() * 400 + 100);
+
+    console.log(`Sleeping for ${sleepDuration}ms`);
 
     switch (type) {
       case 0: {
-        http.get("http://localhost:8080");
-        break;
+        console.log("GET /");
+        await fetch("http://localhost:8080");
       }
 
       case 1: {
-        http.get("http://localhost:8080/async");
-        break;
+        console.log("GET /async");
+        await fetch("http://localhost:8080/async");
       }
 
       case 2: {
-        http.get("http://localhost:8080/bad");
-        break;
+        console.log("GET /bad");
+        await fetch("http://localhost:8080/bad");
       }
 
-      default:
-        break;
+      default: {
+        console.log("none");
+      }
     }
+
+    sleep(sleepDuration);
   }
 }
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
 
 // We delay firing the sample traffic 1s to ensure
 // Prometheus can pick up the newly registered metrics

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -102,7 +102,7 @@ function init(modules: { typescript: typeof tsserver }) {
         prometheusBase,
       );
 
-      const errorRatio = createErrorRatioQuery("caller", nodeIdentifier);
+      const errorRatio = createErrorRatioQuery("function", nodeIdentifier);
       const errorRatioUrl = makePrometheusUrl(errorRatio, prometheusBase);
 
       const calleeErrorRatio = createErrorRatioQuery("caller", nodeIdentifier);


### PR DESCRIPTION
While playing with the sample apps, I noticed that the TypeScript plugin was generating wrong queries. Some PromQL queries were false while others were outright broken. This PR rectifies that:

- uses `function_calls_` regex to grab the Autometrics-instrumented metrics
- correctly inserting `function` as opposed to `caller` where it should
- fixing up some templates that had PromQL syntax errors
