### PR TITLE
Set Parcel plugin version to 0.1.0

### DIFF
--- a/packages/parcel-transformer-autometrics/package.json
+++ b/packages/parcel-transformer-autometrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autometrics/parcel-transformer-autometrics",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "description": "Parcel transformer plugin for Autometrics",
   "author": "Fiberplane<info@fiberplane.com>",
   "contributors": [


### PR DESCRIPTION
Sets the Parcel plugin version to publish initial version.