### PR TITLE
Fix typescript plugin with typescript 5 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.5.3] - 2023-06-26
+
+### Changed
+
+- Fixed issue with running the typescript plugin in combination with typescript 5 (and also fix issues when the vscode extension is bundled with a different version of typescript compared to what vscode is using)
+
 ## [v0.5.2] - 2023-06-16
 
 ### Added 

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autometrics/typescript-plugin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Language service plugin for Autometrics",
   "author": "Fiberplane<info@fiberplane.com>",
   "contributors": [

--- a/packages/typescript-plugin/src/types/index.ts
+++ b/packages/typescript-plugin/src/types/index.ts
@@ -1,1 +1,4 @@
+import type tsserver from "typescript/lib/tsserverlibrary";
+
+export type Tsserver = typeof tsserver;
 export * from "./nodeType";


### PR DESCRIPTION
This is done by tweaking the logic slightly (typescript 5 returns a slightly different AST tree) and also use the typescript util functions that are passed into the plugin. This is important because the vscode extension currently bundles a typescript version which might be different from the one that the project is using. And given that typescript relies on enums with numbers, we can run into issues where the value 357 for SyntaxKind might mean one thing in one version and something completely different in another typescript version.