### PR TITLE
Bump version for the Parcel plugin

### DIFF
--- a/packages/parcel-transformer-autometrics/package.json
+++ b/packages/parcel-transformer-autometrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autometrics/parcel-transformer-autometrics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Parcel transformer plugin for Autometrics",
   "author": "Fiberplane<info@fiberplane.com>",
   "contributors": [


### PR DESCRIPTION
Quick change to make sure the publish workflow is being triggered on the CI for the new Parcel plugin