### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/publish_lib_to_npm.yml
+++ b/.github/workflows/publish_lib_to_npm.yml
@@ -42,6 +42,6 @@ jobs:
       - run: npm ci
 
       - run: npm run build --workspace=@autometrics/autometrics --workspace=autometrics
-      - run: npm publish --workspace=@autometrics/autometrics --workspace=autometrics 
+      - run: npm run release --workspace=@autometrics/autometrics --workspace=autometrics 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_parcel_plugin_to_npm.yml
+++ b/.github/workflows/publish_parcel_plugin_to_npm.yml
@@ -42,7 +42,7 @@ jobs:
       - run: npm ci
 
       - run: npm run build --workspace=@autometrics/parcel-transformer-autometrics
-      - run: npm run publish --workspace=@autometrics/parcel-transformer-autometrics
+      - run: npm run release --workspace=@autometrics/parcel-transformer-autometrics
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish_typescript_plugin_to_npm.yml
+++ b/.github/workflows/publish_typescript_plugin_to_npm.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm ci
 
       - run: npm run build --workspace=@autometrics/typescript-plugin
-      - run: npm run publish --workspace=@autometrics/typescript-plugin
+      - run: npm run release --workspace=@autometrics/typescript-plugin
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/autometrics/package.json
+++ b/packages/autometrics/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf ./dist/",
     "build": "tsc",
     "dev": "tsc --watch",
-    "publish": "npm publish"
+    "release": "npm publish"
   },
   "devDependencies": {
     "@types/node": "^18.14.6",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,7 +22,7 @@
     "build": "tsup",
     "docs": "typedoc",
     "dev": "tsup --watch",
-    "publish": "npm publish"
+    "release": "npm publish"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/packages/parcel-transformer-autometrics/package.json
+++ b/packages/parcel-transformer-autometrics/package.json
@@ -20,7 +20,7 @@
     "dev": "tsc --watch",
     "build": "tsc",
     "clean": "rm -rf dist/",
-    "publish": "npm publish"
+    "release": "npm publish"
   },
   "dependencies": {
     "@parcel/plugin": "^2.9.0",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -20,7 +20,7 @@
     "dev": "tsc --watch",
     "build": "tsc",
     "clean": "rm -rf dist/",
-    "publish": "npm publish"
+    "release": "npm publish"
   },
   "devDependencies": {
     "typescript": ">=4.9.4"


### PR DESCRIPTION
@flenter noticed that publishing workflow would sometimes get stuck in an
infinite loop. This was because we were re-using a probably reserved keyword
`publish` when calling the script. This update changes all script keywords to
`release` and updates the relevant Github Actions. The publishing workflow
itself remains unchanged.

