### PR TITLE
Add `recordErrorIf` and `recordSuccessIf` callbacks

### DIFF
--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -62,7 +62,7 @@ export function getModulePath(): string | undefined {
    */
   const wrappedFunctionPath =
     stack.find((call) => {
-      if (call.name === "__decorateClass") return true;
+      if (call.name?.includes("__decorate")) return true;
     })?.file ?? stack[2]?.file;
 
   const containsFileProtocol = wrappedFunctionPath.includes("file://");

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -36,7 +36,7 @@ type AnyFunction<T extends FunctionSig> = (
 breaks the language server plugin */
 interface AutometricsWrapper<T extends AnyFunction<T>> extends AnyFunction<T> {}
 
-export type AutometricsOptions = {
+export type AutometricsOptions<F extends FunctionSig> = {
   /**
    * Name of your function. Only necessary if using the decorator/wrapper on the
    * client side where builds get minified.
@@ -59,7 +59,42 @@ export type AutometricsOptions = {
    * handler that passes requests off to other functions. (default: `false`)
    */
   trackConcurrency?: boolean;
+  /**
+   * A custom callback function that determines whether a function return should
+   * be considered an error by Autometrics. This may be most useful in
+   * top-level functions such as the HTTP handler which would catch any errors
+   * thrown called from inside the handler.
+   *
+   * @example
+   * ```typescript
+   * async function createUser(payload: User) {
+   *  // ...
+   * }
+   *
+   * // This will record an error if the handler response status is 4xx or 5xx
+   * const recordErrorIf = (res) => res.status >= 400;
+   *
+   * app.post("/users", autometrics({ recordErrorIf }, createUser)
+   * ```
+   */
+  recordErrorIf?: ReportErrorCondition<F>;
+  /**
+   * A custom callback function that determines whether a function result
+   * should be considered a success (regardless if it threw an error). This
+   * may be most useful when you want to ignore certain errors that are thrown
+   * by the function.
+   *
+   */
+  recordSuccessIf?: ReportSuccessCondition;
 };
+
+type ReportErrorCondition<F extends FunctionSig> = (
+  result: Promise<ReturnType<F>> | ReturnType<F>,
+) => Promise<boolean> | boolean;
+
+type ReportSuccessCondition = (
+  result: Promise<Error> | Error,
+) => Promise<boolean> | boolean;
 
 /**
  * Autometrics wrapper for **functions** (requests handlers or database methods)
@@ -118,7 +153,7 @@ export type AutometricsOptions = {
  *
  */
 export function autometrics<F extends FunctionSig>(
-  functionOrOptions: F | AutometricsOptions,
+  functionOrOptions: F | AutometricsOptions<F>,
   fnInput?: F,
 ): AutometricsWrapper<F> {
   let functionName: string;
@@ -126,6 +161,8 @@ export function autometrics<F extends FunctionSig>(
   let fn: F;
   let objective: Objective | undefined;
   let trackConcurrency = false;
+  let recordErrorIf: ReportErrorCondition<F> | undefined;
+  let recordSuccessIf: ReportSuccessCondition | undefined;
 
   if (typeof functionOrOptions === "function") {
     fn = functionOrOptions;
@@ -149,6 +186,14 @@ export function autometrics<F extends FunctionSig>(
 
     if ("trackConcurrency" in functionOrOptions) {
       trackConcurrency = functionOrOptions.trackConcurrency;
+    }
+
+    if ("recordErrorIf" in functionOrOptions) {
+      recordErrorIf = functionOrOptions.recordErrorIf;
+    }
+
+    if ("recordSuccessIf" in functionOrOptions) {
+      recordSuccessIf = functionOrOptions.recordSuccessIf;
     }
   }
 
@@ -256,25 +301,40 @@ export function autometrics<F extends FunctionSig>(
       }
     };
 
+    const recordSuccess = (res: ReturnType<F> | Promise<ReturnType<F>>) => {
+      if (recordErrorIf?.(res)) {
+        onError();
+      } else {
+        onSuccess();
+      }
+    };
+
+    const recordError = (err: Error) => {
+      if (recordSuccessIf?.(err)) {
+        onSuccess();
+      } else {
+        onError();
+      }
+    };
+
     function instrumentedFunction() {
       try {
         const result = fn.apply(this, params);
         if (isPromise<ReturnType<F>>(result)) {
           return result
             .then((res: Awaited<ReturnType<typeof result>>) => {
-              onSuccess();
+              recordSuccess(res);
               return res;
             })
-            .catch((err: unknown) => {
-              onError();
+            .catch((err: Error) => {
+              recordError(err);
               throw err;
             });
         }
-
-        onSuccess();
+        recordSuccess(result);
         return result;
       } catch (error) {
-        onError();
+        recordError(error);
         throw error;
       }
     }
@@ -291,13 +351,13 @@ export function autometrics<F extends FunctionSig>(
 }
 
 export type AutometricsClassDecoratorOptions = Omit<
-  AutometricsOptions,
+  AutometricsOptions<FunctionSig>,
   "functionName"
 >;
 
-type AutometricsDecoratorOptions<T> = T extends Function
+type AutometricsDecoratorOptions<F> = F extends FunctionSig
   ? AutometricsClassDecoratorOptions
-  : AutometricsOptions;
+  : AutometricsOptions<FunctionSig>;
 
 /**
  * Autometrics decorator that can be applied to either a class or class method
@@ -394,7 +454,7 @@ export function Autometrics<T extends Function | Object>(
  * @param autometricsOptions
  */
 export function getAutometricsMethodDecorator(
-  autometricsOptions?: AutometricsOptions,
+  autometricsOptions?: AutometricsOptions<FunctionSig>,
 ) {
   return function (
     _target: Object,

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -22,7 +22,7 @@ if (typeof window === "undefined") {
 // Function Wrapper
 // This seems to be the preferred way for defining functions in TypeScript
 // rome-ignore lint/suspicious/noExplicitAny:
-type FunctionSig = (...args: any[]) => any;
+export type FunctionSig = (...args: any[]) => any;
 
 type AnyFunction<T extends FunctionSig> = (
   ...params: Parameters<T>
@@ -88,11 +88,11 @@ export type AutometricsOptions<F extends FunctionSig> = {
   recordSuccessIf?: ReportSuccessCondition;
 };
 
-type ReportErrorCondition<F extends FunctionSig> = (
+export type ReportErrorCondition<F extends FunctionSig> = (
   result: Promise<ReturnType<F>> | ReturnType<F>,
 ) => Promise<boolean> | boolean;
 
-type ReportSuccessCondition = (
+export type ReportSuccessCondition = (
   result: Promise<Error> | Error,
 ) => Promise<boolean> | boolean;
 


### PR DESCRIPTION
> Note: the PR seems sizeable but most of the action is happening in the `wrappers.ts` file. The rest is just example apps updates.

This PR is an initial implementation of the issue raised in #82 - ensuring that Autometrics wrapper can correctly record errors even if they are handled in the wrapped original handling. It also adds the ability to record successes even if the original wrapped function threw an error which is useful for cases when the thrown errors should be ignored.

Both conditions are added as `recordErrorIf` and `recordSuccessIf` callbacks to the `AutometricsOptions` object optionally placed in the first parameter place.

### Example

Given a function `createUser` that (importantly) _returns_ a status code 201 on successful POST request:

```typescript
async function createUser(user: User) {
    // ...
    return res.status(201)
}
```

We can define a `recordErrorIf` callback and pass it to the `autometrics` wrapper:

```typescript

const recordErrorIf = async (res: express.Response) => {
    return await res.statusCode >= 400 && res.statusCode <= 599;
}

app.post("/users/:id", autometrics({ recordErrorIf }, createUser))
```

Now any calls that return with a status code of 4xx or 5xx will be reported as errors to Autometrics even if `createUser` catches the thrown errors.

Other: PR removes `svelte` example for now given that the library is mostly tested in the backend.

- remove svelte files for now
- add a better express example
- add server.ts
- update deps
- update server.ts
- add recordErrorIf and recordOkIf callbacks as parameters
