### PR TITLE
Refactor `getModulePath` and fix decorator errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed an issue where decorators were changing `this` values for the methods they'd be wrapping, breaking them.
+- Improved how `getModulePath` utility works, passing stack trace as structured data, and making it more robust.
+
 ## [v0.5.3] - 2023-06-26
 
 ### Changed

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -21,10 +21,10 @@ export function getRuntime(): Runtime {
 // given function e.g.: dist/index.js
 export function getModulePath(): string | undefined {
   const defaultPrepareStackTrace = Error.prepareStackTrace;
-  Error.prepareStackTrace = (error, stack) => stack;
-  // @ts-ignore: TS doesn't recognize that we've overwritten
-  // the default "stack" property
-  const { stack: stackConstructor }: { stack: NodeJS.CallSite[] } = new Error();
+  Error.prepareStackTrace = (_, stack) => stack;
+  const { stack: stackConstructor } = new Error() as Error & {
+    stack: NodeJS.CallSite[];
+  };
   Error.prepareStackTrace = defaultPrepareStackTrace; // we have to make sure to reset this to normal
 
   const stack = stackConstructor.map((callSite) => ({

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -20,13 +20,20 @@ export function getRuntime(): Runtime {
 // HACK: this entire function is a hacky way to acquire the module name for a
 // given function e.g.: dist/index.js
 export function getModulePath(): string | undefined {
-  Error.stackTraceLimit = 5;
-  const stack = new Error()?.stack?.split("\n");
+  const defaultPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = (error, stack) => stack;
+  // @ts-ignore: TS doesn't recognize that we've overwritten
+  // the default "stack" property
+  const { stack: stackConstructor }: { stack: NodeJS.CallSite[] } = new Error();
+  Error.prepareStackTrace = defaultPrepareStackTrace; // we have to make sure to reset this to normal
+
+  const stack = stackConstructor.map((callSite) => ({
+    name: callSite.getFunctionName(),
+    file: callSite.getFileName(),
+  }));
 
   let rootDir: string;
-
   const runtime = getRuntime();
-
   if (runtime === "browser") {
     rootDir = "";
   } else if (runtime === "deno") {
@@ -45,28 +52,27 @@ export function getModulePath(): string | undefined {
   }
 
   /**
+   * Finds the original wrapped function, first it checks if it's a decorator,
+   * and returns that filename or gets the 3th item of the stack trace:
    *
    * 0: Error
-   * 1: at getModulePath() ...
-   * 2: at autometrics() ...
-   * 3: at ... -> 4th line is always the original caller
+   * 1: at getModulePath ...
+   * 2: at autometrics ...
+   * 3: at ... -> 4th line is always the original wrapped function
    */
-  const originalCaller = 3 as const;
+  const wrappedFunctionPath =
+    stack.find((call) => {
+      if (call.name === "__decorateClass") return true;
+    })?.file ?? stack[2]?.file;
 
-  // The last element in this array will have the full path
-  const fullPath = stack[originalCaller].split(" ").pop();
-
-  const containsFileProtocol = fullPath.includes("file://");
+  const containsFileProtocol = wrappedFunctionPath.includes("file://");
 
   // We split away everything up to the root directory of the project,
   // if the path contains file:// we need to remove it
-  let modulePath = fullPath.replace(
+  const modulePath = wrappedFunctionPath.replace(
     containsFileProtocol ? `file://${rootDir}` : rootDir,
     "",
   );
-
-  // We split away the line and column numbers index.js:14:6
-  modulePath = modulePath.substring(0, modulePath.indexOf(":"));
 
   return modulePath;
 }

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -69,12 +69,10 @@ export function getModulePath(): string | undefined {
 
   // We split away everything up to the root directory of the project,
   // if the path contains file:// we need to remove it
-  const modulePath = wrappedFunctionPath.replace(
+  return wrappedFunctionPath.replace(
     containsFileProtocol ? `file://${rootDir}` : rootDir,
     "",
   );
-
-  return modulePath;
 }
 
 type ALSContext = {

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -250,7 +250,7 @@ export function autometrics<F extends FunctionSig>(
 
     function instrumentedFunction() {
       try {
-        const result = fn(...params);
+        const result = fn.apply(this, params);
         if (isPromise<ReturnType<F>>(result)) {
           return result
             .then((res: Awaited<ReturnType<typeof result>>) => {


### PR DESCRIPTION
This PR fixes several issues:
- Decorators were throwing out `this` values for the methods they were wrapping. Core wrapper `autometrics` now uses `Function.apply` to preserve the `this` context.
- Using `Function.apply` also doesn't require copying all of the parameters using the spread operator which should reduce memory footprint for functions that have large parameter objects they're passing around.
- Refactors `getModulePath` utility: it now constructs a custom stack trace with only the necessary information to get the filename without string parsing.

It also adds a test to ensure decorators work properly.
