### PR TITLE
Use seconds instead of milliseconds for histograms

### DIFF
--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -261,7 +261,7 @@ export function autometrics<F extends FunctionSig>(
     }
 
     const onSuccess = () => {
-      const autometricsDuration = performance.now() - autometricsStart;
+      const autometricsDuration = (performance.now() - autometricsStart) / 1000;
 
       counter.add(1, {
         function: functionName,
@@ -287,7 +287,7 @@ export function autometrics<F extends FunctionSig>(
     };
 
     const onError = () => {
-      const autometricsDuration = performance.now() - autometricsStart;
+      const autometricsDuration = (performance.now() - autometricsStart) / 1000;
 
       counter.add(1, {
         function: functionName,


### PR DESCRIPTION
Per [the spec](https://github.com/autometrics-dev/autometrics-shared/blob/f6f084ad1391ed1ad9de5c484cfa836a8311fcf6/SPEC.md?plain=1#L92), `autometrics-ts` should report histogram in seconds units as opposed to ms. Closes #93 