### PR TITLE
Improve API reference

### DIFF
--- a/packages/lib/reference/README.md
+++ b/packages/lib/reference/README.md
@@ -1,72 +1,86 @@
 # @autometrics/autometrics
 
-## Enumerations
+## Initialization API
 
-- [ObjectiveLatency](enums/ObjectiveLatency.md)
-- [ObjectivePercentile](enums/ObjectivePercentile.md)
+### BuildInfo
 
-## Type Aliases
+Ƭ **BuildInfo**: `Object`
 
-### AutometricsClassDecoratorOptions
-
-Ƭ **AutometricsClassDecoratorOptions**: `Omit`<[`AutometricsOptions`](README.md#autometricsoptions)<[`FunctionSig`](README.md#functionsig)\>, ``"functionName"``\>
-
-#### Defined in
-
-[wrappers.ts:375](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L375)
-
-___
-
-### AutometricsOptions
-
-Ƭ **AutometricsOptions**<`F`\>: `Object`
-
-#### Type parameters
-
-| Name | Type |
-| :------ | :------ |
-| `F` | extends [`FunctionSig`](README.md#functionsig) |
+BuildInfo is used to create the `build_info` metric that
+helps to identify the version, commit, and branch of the
+application, the metrics of which are being collected.
 
 #### Type declaration
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `functionName?` | `string` | Name of your function. Only necessary if using the decorator/wrapper on the client side where builds get minified. |
-| `moduleName?` | `string` | Name of the module (usually filename) |
-| `objective?` | [`Objective`](README.md#objective) | Include this function's metrics in the specified objective or SLO. See the docs for [Objective](README.md#objective) for details on how to create objectives. |
-| `recordErrorIf?` | [`ReportErrorCondition`](README.md#reporterrorcondition)<`F`\> | A custom callback function that determines whether a function return should be considered an error by Autometrics. This may be most useful in top-level functions such as the HTTP handler which would catch any errors thrown called from inside the handler. **`Example`** ```typescript async function createUser(payload: User) { // ... } // This will record an error if the handler response status is 4xx or 5xx const recordErrorIf = (res) => res.status >= 400; app.post("/users", autometrics({ recordErrorIf }, createUser) ``` |
-| `recordSuccessIf?` | [`ReportSuccessCondition`](README.md#reportsuccesscondition) | A custom callback function that determines whether a function result should be considered a success (regardless if it threw an error). This may be most useful when you want to ignore certain errors that are thrown by the function. |
-| `trackConcurrency?` | `boolean` | Pass this argument to track the number of concurrent calls to the function (using a gauge). This may be most useful for top-level functions such as the main HTTP handler that passes requests off to other functions. (default: `false`) |
+| `branch?` | `string` | The current commit hash of the application. Should be set through an environment variable: `AUTOMETRICS_BRANCH` or `BRANCH_NAME`. |
+| `commit?` | `string` | The current commit hash of the application. Should be set through an environment variable: `AUTOMETRICS_COMMIT` or `COMMIT_SHA`. |
+| `version?` | `string` | The current version of the application. Should be set through an environment variable: `AUTOMETRICS_VERSION` or `PACKAGE_VERSION`. |
 
 #### Defined in
 
-[wrappers.ts:47](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L47)
+[buildInfo.ts:13](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/buildInfo.ts#L13)
 
 ___
 
-### FunctionSig
+### initOptions
 
-Ƭ **FunctionSig**: (...`args`: `any`[]) => `any`
+Ƭ **initOptions**: `Object`
 
 #### Type declaration
 
-▸ (`...args`): `any`
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `...args` | `any`[] |
-
-##### Returns
-
-`any`
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `buildInfo?` | [`BuildInfo`](README.md#buildinfo) | Optional build info to be added to the build_info metric (necessary for client-side applications). See [BuildInfo](README.md#buildinfo) |
+| `exporter?` | `Exporter` | A custom exporter to be used instead of the bundled Prometheus Exporter on port 9464 |
+| `pushGateway?` | `string` | The full URL (including http://) of the aggregating push gateway for metrics to be submitted to. |
+| `pushInterval?` | `number` | Set a custom push interval in ms (default: 5000ms) |
 
 #### Defined in
 
-[wrappers.ts:33](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L33)
+[instrumentation.ts:22](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/instrumentation.ts#L22)
 
 ___
+
+### init
+
+▸ **init**(`options`): `void`
+
+Optional initialization function to set a custom exporter or push gateway for client-side applications.
+Required if using autometrics in a client-side application. See [initOptions](README.md#initoptions) for details.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options` | [`initOptions`](README.md#initoptions) |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[instrumentation.ts:50](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/instrumentation.ts#L50)
+
+## Service Level Objective API
+
+• **ObjectiveLatency**: `Object`
+
+The latency threshold, in milliseconds, for a given objective.
+
+#### Defined in
+
+[objectives.ts:73](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L73)
+
+• **ObjectivePercentile**: `Object`
+
+The percentage of requests that must meet the given criteria (success rate or latency)
+
+#### Defined in
+
+[objectives.ts:49](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L49)
 
 ### Objective
 
@@ -117,82 +131,36 @@ However, they are enabled when the special labels are present on certain metrics
 
 #### Defined in
 
-[objectives.ts:36](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L36)
+[objectives.ts:38](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L38)
 
-___
+## Wrapper and Decorator API
 
-### ReportErrorCondition
+### AutometricsOptions
 
-Ƭ **ReportErrorCondition**<`F`\>: (`result`: `Awaited`<`ReturnType`<`F`\>\>) => `boolean`
+Ƭ **AutometricsOptions**<`F`\>: `Object`
 
 #### Type parameters
 
 | Name | Type |
 | :------ | :------ |
-| `F` | extends [`FunctionSig`](README.md#functionsig) |
-
-#### Type declaration
-
-▸ (`result`): `boolean`
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `result` | `Awaited`<`ReturnType`<`F`\>\> |
-
-##### Returns
-
-`boolean`
-
-#### Defined in
-
-[wrappers.ts:99](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L99)
-
-___
-
-### ReportSuccessCondition
-
-Ƭ **ReportSuccessCondition**: (`result`: `Error`) => `boolean`
-
-#### Type declaration
-
-▸ (`result`): `boolean`
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `result` | `Error` |
-
-##### Returns
-
-`boolean`
-
-#### Defined in
-
-[wrappers.ts:103](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L103)
-
-___
-
-### initOptions
-
-Ƭ **initOptions**: `Object`
+| `F` | extends `FunctionSig` |
 
 #### Type declaration
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `buildInfo?` | `BuildInfo` | Optional build info to be added to the build_info metric (necessary for client-side applications). See BuildInfo |
-| `exporter?` | `Exporter` | A custom exporter to be used instead of the bundled Prometheus Exporter on port 9464 |
-| `pushGateway?` | `string` | The full URL (including http://) of the aggregating push gateway for metrics to be submitted to. |
-| `pushInterval?` | `number` | Set a custom push interval in ms (default: 5000ms) |
+| `functionName?` | `string` | Name of your function. Only necessary if using the decorator/wrapper on the client side where builds get minified. |
+| `moduleName?` | `string` | Name of the module (usually filename) |
+| `objective?` | [`Objective`](README.md#objective) | Include this function's metrics in the specified objective or SLO. See the docs for [Objective](README.md#objective) for details on how to create objectives. |
+| `recordErrorIf?` | `ReportErrorCondition`<`F`\> | A custom callback function that determines whether a function return should be considered an error by Autometrics. This may be most useful in top-level functions such as the HTTP handler which would catch any errors thrown called from inside the handler. **`Example`** ```typescript async function createUser(payload: User) { // ... } // This will record an error if the handler response status is 4xx or 5xx const recordErrorIf = (res) => res.status >= 400; app.post("/users", autometrics({ recordErrorIf }, createUser) ``` |
+| `recordSuccessIf?` | `ReportSuccessCondition` | A custom callback function that determines whether a function result should be considered a success (regardless if it threw an error). This may be most useful when you want to ignore certain errors that are thrown by the function. |
+| `trackConcurrency?` | `boolean` | Pass this argument to track the number of concurrent calls to the function (using a gauge). This may be most useful for top-level functions such as the main HTTP handler that passes requests off to other functions. (default: `false`) |
 
 #### Defined in
 
-[instrumentation.ts:19](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/instrumentation.ts#L19)
+[wrappers.ts:53](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/wrappers.ts#L53)
 
-## Functions
+___
 
 ### Autometrics
 
@@ -312,7 +280,7 @@ class Foo {
 
 #### Defined in
 
-[wrappers.ts:443](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L443)
+[wrappers.ts:463](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/wrappers.ts#L463)
 
 ___
 
@@ -373,7 +341,7 @@ const user = createUser();
 
 | Name | Type |
 | :------ | :------ |
-| `F` | extends [`FunctionSig`](README.md#functionsig) |
+| `F` | extends `FunctionSig` |
 
 #### Parameters
 
@@ -388,88 +356,4 @@ const user = createUser();
 
 #### Defined in
 
-[wrappers.ts:161](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L161)
-
-___
-
-### getAutometricsClassDecorator
-
-▸ **getAutometricsClassDecorator**(`autometricsOptions?`): `ClassDecorator`
-
-Decorator factory that returns a class decorator that instruments all methods
-of a class with autometrics. Optionally accepts an autometrics options
-object.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `autometricsOptions?` | [`AutometricsClassDecoratorOptions`](README.md#autometricsclassdecoratoroptions) |
-
-#### Returns
-
-`ClassDecorator`
-
-#### Defined in
-
-[wrappers.ts:502](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L502)
-
-___
-
-### getAutometricsMethodDecorator
-
-▸ **getAutometricsMethodDecorator**(`autometricsOptions?`): (`_target`: `Object`, `_propertyKey`: `string`, `descriptor`: `PropertyDescriptor`) => `PropertyDescriptor`
-
-Decorator factory that returns a method decorator. Optionally accepts
-an autometrics options object.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `autometricsOptions?` | [`AutometricsOptions`](README.md#autometricsoptions)<[`FunctionSig`](README.md#functionsig)\> |
-
-#### Returns
-
-`fn`
-
-▸ (`_target`, `_propertyKey`, `descriptor`): `PropertyDescriptor`
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `_target` | `Object` |
-| `_propertyKey` | `string` |
-| `descriptor` | `PropertyDescriptor` |
-
-##### Returns
-
-`PropertyDescriptor`
-
-#### Defined in
-
-[wrappers.ts:478](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/wrappers.ts#L478)
-
-___
-
-### init
-
-▸ **init**(`options`): `void`
-
-Optional initialization function to set a custom exporter or push gateway for client-side applications.
-Required if using autometrics in a client-side application. See [initOptions](README.md#initoptions) for details.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `options` | [`initOptions`](README.md#initoptions) |
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[instrumentation.ts:46](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/instrumentation.ts#L46)
+[wrappers.ts:176](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/wrappers.ts#L176)

--- a/packages/lib/reference/enums/ObjectiveLatency.md
+++ b/packages/lib/reference/enums/ObjectiveLatency.md
@@ -12,7 +12,7 @@ The latency threshold, in milliseconds, for a given objective.
 
 #### Defined in
 
-[objectives.ts:75](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L75)
+[objectives.ts:81](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L81)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:91](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L91)
+[objectives.ts:97](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L97)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:107](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L107)
+[objectives.ts:113](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L113)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:123](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L123)
+[objectives.ts:129](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L129)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:79](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L79)
+[objectives.ts:85](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L85)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:95](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L95)
+[objectives.ts:101](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L101)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:111](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L111)
+[objectives.ts:117](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L117)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:71](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L71)
+[objectives.ts:77](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L77)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:83](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L83)
+[objectives.ts:89](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L89)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:99](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L99)
+[objectives.ts:105](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L105)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:115](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L115)
+[objectives.ts:121](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L121)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:87](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L87)
+[objectives.ts:93](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L93)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:103](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L103)
+[objectives.ts:109](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L109)
 
 ___
 
@@ -168,4 +168,4 @@ ___
 
 #### Defined in
 
-[objectives.ts:119](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L119)
+[objectives.ts:125](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L125)

--- a/packages/lib/reference/enums/ObjectivePercentile.md
+++ b/packages/lib/reference/enums/ObjectivePercentile.md
@@ -12,7 +12,7 @@ The percentage of requests that must meet the given criteria (success rate or la
 
 #### Defined in
 
-[objectives.ts:49](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L49)
+[objectives.ts:53](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L53)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:53](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L53)
+[objectives.ts:57](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L57)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[objectives.ts:57](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L57)
+[objectives.ts:61](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L61)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[objectives.ts:61](https://github.com/autometrics-dev/autometrics-ts/blob/54e7cc0/packages/lib/src/objectives.ts#L61)
+[objectives.ts:65](https://github.com/autometrics-dev/autometrics-ts/blob/db1e410/packages/lib/src/objectives.ts#L65)

--- a/packages/lib/src/buildInfo.ts
+++ b/packages/lib/src/buildInfo.ts
@@ -7,16 +7,42 @@ import { BUILD_INFO_DESCRIPTION, BUILD_INFO_NAME } from "./constants";
  * BuildInfo is used to create the `build_info` metric that
  * helps to identify the version, commit, and branch of the
  * application, the metrics of which are being collected.
+ *
+ * @group Initialization API
  */
 export type BuildInfo = {
+  /**
+   * The current version of the application. Should be set through an
+   * environment variable: `AUTOMETRICS_VERSION` or `PACKAGE_VERSION`.
+   */
   version?: string;
+  /**
+   * The current commit hash of the application. Should be set through an
+   * environment variable: `AUTOMETRICS_COMMIT` or `COMMIT_SHA`.
+   */
   commit?: string;
+  /**
+   * The current commit hash of the application. Should be set through an
+   * environment variable: `AUTOMETRICS_BRANCH` or `BRANCH_NAME`.
+   */
   branch?: string;
 };
 
+/**
+ * The build info of the application.
+ *
+ * Should be set through the `init` function.
+ *
+ * @internal
+ */
 export let buildInfo: BuildInfo = {};
 let buildInfoGauge: UpDownCounter;
 
+/**
+ * Records the build info for the application.
+ *
+ * @internal
+ */
 export function recordBuildInfo(buildInfo: BuildInfo) {
   if (!buildInfoGauge) {
     buildInfoGauge = getMeter().createUpDownCounter(BUILD_INFO_NAME, {
@@ -27,6 +53,11 @@ export function recordBuildInfo(buildInfo: BuildInfo) {
   buildInfoGauge.add(1, buildInfo);
 }
 
+/**
+ * Sets the build info for the application.
+ *
+ * @internal
+ */
 export function setBuildInfo() {
   if (Object.keys(buildInfo).length > 0) {
     return buildInfo;
@@ -45,6 +76,11 @@ export function setBuildInfo() {
   return buildInfo;
 }
 
+/**
+ * Gets the version of the application.
+ *
+ * @internal
+ */
 function getVersion(runtime: Runtime): string | undefined {
   if (runtime === "node") {
     if (process.env.npm_package_version) {
@@ -61,6 +97,11 @@ function getVersion(runtime: Runtime): string | undefined {
   }
 }
 
+/**
+ * Gets the commit hash of the current state of the application.
+ *
+ * @internal
+ */
 function getCommit(runtime: Runtime) {
   if (runtime === "node") {
     return process.env.COMMIT_SHA || process.env.AUTOMETRICS_COMMIT;
@@ -72,6 +113,11 @@ function getCommit(runtime: Runtime) {
   }
 }
 
+/**
+ * Gets the current branch of the application.
+ *
+ * @internal
+ */
 function getBranch(runtime: Runtime) {
   if (runtime === "node") {
     return process.env.BRANCH_NAME || process.env.AUTOMETRICS_BRANCH;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,4 @@
 export { init, type initOptions } from "./instrumentation";
 export * from "./objectives";
 export * from "./wrappers";
+export * from "./buildInfo";

--- a/packages/lib/src/instrumentation.ts
+++ b/packages/lib/src/instrumentation.ts
@@ -16,6 +16,9 @@ let exporter: MetricReader;
 
 type Exporter = MetricReader;
 
+/**
+ * @group Initialization API
+ */
 export type initOptions = {
   /**
    * A custom exporter to be used instead of the bundled Prometheus Exporter on port 9464
@@ -42,6 +45,7 @@ export type initOptions = {
  * Required if using autometrics in a client-side application. See {@link initOptions} for details.
  *
  * @param {initOptions} options
+ * @group Initialization API
  */
 export function init(options: initOptions) {
   logger("Using the user's Exporter configuration");

--- a/packages/lib/src/objectives.ts
+++ b/packages/lib/src/objectives.ts
@@ -32,6 +32,8 @@
  *
  * By default, these recording rules will effectively lay dormant.
  * However, they are enabled when the special labels are present on certain metrics.
+ *
+ * @group Service Level Objective API
  */
 export type Objective = {
   name: string;
@@ -41,6 +43,8 @@ export type Objective = {
 
 /**
  * The percentage of requests that must meet the given criteria (success rate or latency)
+ *
+ * @group Service Level Objective API
  */
 export enum ObjectivePercentile {
   /**
@@ -63,6 +67,8 @@ export enum ObjectivePercentile {
 
 /**
  * The latency threshold, in milliseconds, for a given objective.
+ *
+ * @group Service Level Objective API
  */
 export enum ObjectiveLatency {
   /**

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -27,8 +27,11 @@ if (typeof window === "undefined") {
   })();
 }
 
-// Function Wrapper
-// This seems to be the preferred way for defining functions in TypeScript
+/**
+ * Function Wrapper
+ * This seems to be the preferred way for defining functions in TypeScript
+ * @internal
+ */
 // rome-ignore lint/suspicious/noExplicitAny:
 export type FunctionSig = (...args: any[]) => any;
 
@@ -44,14 +47,20 @@ type AnyFunction<T extends FunctionSig> = (
 breaks the language server plugin */
 interface AutometricsWrapper<T extends AnyFunction<T>> extends AnyFunction<T> {}
 
+/**
+ * @group Wrapper and Decorator API
+ */
 export type AutometricsOptions<F extends FunctionSig> = {
   /**
    * Name of your function. Only necessary if using the decorator/wrapper on the
    * client side where builds get minified.
+   *
+   * @group Wrapper and Decorator API
    */
   functionName?: string;
   /**
    * Name of the module (usually filename)
+   * @group Wrapper and Decorator API
    */
   moduleName?: string;
   /**
@@ -96,10 +105,16 @@ export type AutometricsOptions<F extends FunctionSig> = {
   recordSuccessIf?: ReportSuccessCondition;
 };
 
+/**
+ * @internal
+ */
 export type ReportErrorCondition<F extends FunctionSig> = (
   result: Awaited<ReturnType<F>>,
 ) => boolean;
 
+/**
+ * @internal
+ */
 export type ReportSuccessCondition = (result: Error) => boolean;
 
 /**
@@ -156,7 +171,7 @@ export type ReportSuccessCondition = (result: Error) => boolean;
  *
  * const user = createUser();
  * ```
- *
+ * @group Wrapper and Decorator API
  */
 export function autometrics<F extends FunctionSig>(
   functionOrOptions: F | AutometricsOptions<F>,
@@ -372,6 +387,9 @@ export function autometrics<F extends FunctionSig>(
   };
 }
 
+/**
+ * @internal
+ */
 export type AutometricsClassDecoratorOptions = Omit<
   AutometricsOptions<FunctionSig>,
   "functionName"
@@ -439,6 +457,8 @@ type AutometricsDecoratorOptions<F> = F extends FunctionSig
  *   }
  * }
  * ```
+ *
+ * @group Wrapper and Decorator API
  */
 export function Autometrics<T extends Function | Object>(
   autometricsOptions?: AutometricsDecoratorOptions<T>,
@@ -474,6 +494,7 @@ export function Autometrics<T extends Function | Object>(
  * Decorator factory that returns a method decorator. Optionally accepts
  * an autometrics options object.
  * @param autometricsOptions
+ * @internal
  */
 export function getAutometricsMethodDecorator(
   autometricsOptions?: AutometricsOptions<FunctionSig>,
@@ -498,6 +519,7 @@ export function getAutometricsMethodDecorator(
  * of a class with autometrics. Optionally accepts an autometrics options
  * object.
  * @param autometricsOptions
+ * @internal
  */
 export function getAutometricsClassDecorator(
   autometricsOptions?: AutometricsClassDecoratorOptions,

--- a/packages/lib/typedoc.json
+++ b/packages/lib/typedoc.json
@@ -1,6 +1,7 @@
 {
   "readme": "none",
   "entryPoints": ["src/index.ts"],
+  "excludeInternal": true,
   "cleanOutputDir": true,
   "out": "./reference",
   "plugin": ["typedoc-plugin-markdown"],


### PR DESCRIPTION
This PR improves documentation by adding better doc comments, grouping related functions and interfaces. It also updates the typedoc configuration to exclude interfaces marked as internal. Finally it commits the updated generated reference.

Closes #96 
