### PR TITLE
Fix TS Plugin: show hover in wrapped functions

### DIFF
--- a/packages/typescript-plugin/src/astHelpers.ts
+++ b/packages/typescript-plugin/src/astHelpers.ts
@@ -86,10 +86,6 @@ export function getNodeIdentifier(
   typechecker: TypeChecker,
   ts: Tsserver,
 ): string {
-  if (nodeType === "method" && ts.isIdentifier(node)) {
-    return node.escapedText.toString();
-  }
-
   if (nodeType === "function") {
     const declaration = typechecker.getSymbolAtLocation(node).valueDeclaration;
 
@@ -114,11 +110,10 @@ export function getNodeIdentifier(
     ) {
       return declaration.initializer.arguments[0].escapedText.toString();
     }
-
-    // otherwise just return the identifier user is currently hovering over
-    if (ts.isIdentifier(node)) {
-      return node.escapedText.toString();
-    }
+  }
+  // otherwise just return the identifier user is currently hovering over
+  if (ts.isIdentifier(node)) {
+    return node.escapedText.toString();
   }
 }
 

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -58,8 +58,8 @@ function init(modules: { typescript: Tsserver }) {
         ts,
       );
 
-      // If either autometrics checker or node type is undefined return early
-      if (!(autometrics && nodeType)) {
+      // If either autometrics checker return early
+      if (!autometrics) {
         return prior;
       }
 


### PR DESCRIPTION
Closes #91 

This PR fixes an issue where Autometrics hover wouldn't show in cases like this:

```typescript
autometrics(wrappedFunction)
                    ^ -- hovering here
```

Basically it simplifies some redundant logic that prevented the tooltip for showing.