### PR TITLE
Initial Gravel Gateway Support

### DIFF
--- a/packages/lib/src/buildInfo.ts
+++ b/packages/lib/src/buildInfo.ts
@@ -26,6 +26,15 @@ export type BuildInfo = {
    * environment variable: `AUTOMETRICS_BRANCH` or `BRANCH_NAME`.
    */
   branch?: string;
+
+  /**
+   * The "clearmode" label of the `build_info` metric.
+   * This label is used when pushing to a Gravel Gateway
+   *
+   * When pushing to a Gravel Gateway, it's recommended to use the "family" clearmode.
+   * See the Gravel Gateways documentation for more details.
+   */
+  clearmode?: "replace" | "aggregate" | "family" | "";
 };
 
 /**

--- a/packages/lib/src/instrumentation.ts
+++ b/packages/lib/src/instrumentation.ts
@@ -83,9 +83,10 @@ export function init(options: initOptions) {
   // if it is provided - we register it
   if (options.buildInfo) {
     logger("Registering build info");
-    buildInfo.version = options.buildInfo?.version;
-    buildInfo.commit = options.buildInfo?.commit;
-    buildInfo.branch = options.buildInfo?.branch;
+    buildInfo.version = options.buildInfo?.version ?? "";
+    buildInfo.commit = options.buildInfo?.commit ?? "";
+    buildInfo.branch = options.buildInfo?.branch ?? "";
+    buildInfo.clearmode = options.buildInfo?.clearmode ?? "";
     recordBuildInfo(buildInfo); // record build info only after the exporter is initialized
   }
 }

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -227,6 +227,14 @@ export function autometrics<F extends FunctionSig>(
   const counterObjectiveAttributes: Attributes = {};
   const histogramObjectiveAttributes: Attributes = {};
 
+  // NOTE - Gravel Gateway will reject two metrics of the same name if one of them has a subset of the attributes of the other
+  //        This means to be able to support functions that have objectives, as well as functions that don't, we need to
+  //        default to setting the objective_* labels to the empty string.
+  histogramObjectiveAttributes.objective_latency_threshold = "";
+  histogramObjectiveAttributes.objective_percentile = "";
+
+  counterObjectiveAttributes.objective_percentile = "";
+
   if (objective) {
     const { latency, name, successRate } = objective;
 

--- a/packages/lib/src/wrappers.ts
+++ b/packages/lib/src/wrappers.ts
@@ -230,9 +230,11 @@ export function autometrics<F extends FunctionSig>(
   // NOTE - Gravel Gateway will reject two metrics of the same name if one of them has a subset of the attributes of the other
   //        This means to be able to support functions that have objectives, as well as functions that don't, we need to
   //        default to setting the objective_* labels to the empty string.
+  histogramObjectiveAttributes.objective_name = "";
   histogramObjectiveAttributes.objective_latency_threshold = "";
   histogramObjectiveAttributes.objective_percentile = "";
 
+  counterObjectiveAttributes.objective_name = "";
   counterObjectiveAttributes.objective_percentile = "";
 
   if (objective) {

--- a/packages/lib/tests/buildInfo.test.ts
+++ b/packages/lib/tests/buildInfo.test.ts
@@ -33,7 +33,7 @@ describe("Autometrics build info tests", () => {
 
   test("build info is recorded", async () => {
     const buildInfoMetric =
-      /build_info{version="1.0.0",commit="123456789",branch="main"}/gm;
+      /build_info{version="1.0.0",commit="123456789",branch="main",clearmode=""}/gm;
 
     const serialized = await collectAndSerialize(exporter);
 

--- a/packages/lib/tests/objectives.test.ts
+++ b/packages/lib/tests/objectives.test.ts
@@ -97,6 +97,8 @@ describe("Autometrics objectives test", () => {
 
     const serialized = await collectAndSerialize(exporter);
 
+    console.log(serialized);
+
     expect(serialized).toMatch(callCountMetric);
     expect(serialized).toMatch(durationMetric);
   });

--- a/packages/lib/tests/objectives.test.ts
+++ b/packages/lib/tests/objectives.test.ts
@@ -97,8 +97,6 @@ describe("Autometrics objectives test", () => {
 
     const serialized = await collectAndSerialize(exporter);
 
-    console.log(serialized);
-
     expect(serialized).toMatch(callCountMetric);
     expect(serialized).toMatch(durationMetric);
   });


### PR DESCRIPTION
This is a change to support autometrics-ts when used with the gravel aggregation gateway. 

## Allow a `clearmode="family"` label on the `build_info` metrics

Aggregating a gauge like `build_info` requires a special label.

We want to clear previous build_info metrics when new ones are pushed. 

Grave Gateway requires that you add a `clearmode` label to do this.

## Objective labels must always be present

Gravel Gateway will reject two metrics of the same name if one of them has a subset of the labels of the other.

This means to be able to support functions that have objectives, as well as functions that don't, we need to default to setting the `objective_*` labels to the empty string.

## Looking to the Future

- Add support for specifying the job name
- Check that pushing build_info with a new job name does not clear all existing build_info metrics with different job names
