### PR TITLE
Fix issue with using window global in serverless context

### DIFF
--- a/examples/faas-experimental/index.ts
+++ b/examples/faas-experimental/index.ts
@@ -27,7 +27,7 @@ init({
   //
   //        However, everything works fine with aggregation gateways.
   //
-  url: "http://localhost:9092/metrics",
+  url: "http://localhost:8082/metrics",
   pushInterval: 0,
 });
 

--- a/examples/faas-experimental/package.json
+++ b/examples/faas-experimental/package.json
@@ -14,7 +14,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@autometrics/autometrics": "^0.6.0",
+    "@autometrics/autometrics": "^0.7.0-beta5",
     "@autometrics/exporter-prometheus-push-gateway": "^0.7.0-beta5",
     "node-fetch": "^3.3.1"
   }

--- a/packages/exporter-prometheus-push-gateway/package.json
+++ b/packages/exporter-prometheus-push-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autometrics/exporter-prometheus-push-gateway",
-  "version": "0.7.0-beta5",
+  "version": "0.7.0-beta6",
   "type": "module",
   "description": "Export metrics by pushing them to a Prometheus-compatible gateway",
   "author": "Fiberplane <info@fiberplane.com>",

--- a/packages/exporter-prometheus-push-gateway/src/pushGatewayExporter.ts
+++ b/packages/exporter-prometheus-push-gateway/src/pushGatewayExporter.ts
@@ -31,7 +31,10 @@ export class PushGatewayExporter implements PushMetricExporter {
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
 
     this.shutdown = this.shutdown.bind(this);
-    window.addEventListener("unload", this.shutdown);
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("unload", this.shutdown);
+    }
   }
 
   export(
@@ -98,7 +101,9 @@ export class PushGatewayExporter implements PushMetricExporter {
   }
 
   shutdown(): Promise<void> {
-    window.removeEventListener("unload", this.shutdown);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("unload", this.shutdown);
+    }
 
     return this._shutdownOnce.call();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,7 +3439,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "faas-experimental-example@workspace:examples/faas-experimental"
   dependencies:
-    "@autometrics/autometrics": ^0.6.0
+    "@autometrics/autometrics": ^0.7.0-beta5
     "@autometrics/exporter-prometheus-push-gateway": ^0.7.0-beta5
     "@autometrics/typescript-plugin": ^0.5.4
     node-fetch: ^3.3.1


### PR DESCRIPTION
The push gateway exporter has a reference to `window`, which won't be defined for serverless functions.