### PR TITLE
Use delta temporality for React example

### DIFF
--- a/examples/react-app-experimental/src/App.tsx
+++ b/examples/react-app-experimental/src/App.tsx
@@ -1,6 +1,10 @@
-import { useState } from "react";
+import {
+  AggregationTemporalityPreference,
+  init,
+} from "@autometrics/exporter-otlp-http";
 import { autometrics } from "@autometrics/autometrics";
-import { init } from "@autometrics/exporter-otlp-http";
+import { useState } from "react";
+
 import "./App.css";
 
 // In order for Prometheus to succesfully get your client-side app metrics, you
@@ -21,6 +25,9 @@ init({
     commit: import.meta.env.VITE_AUTOMETRICS_COMMIT,
     branch: import.meta.env.VITE_AUTOMETRICS_BRANCH,
   },
+  // Delta temporality is important to allow for correct aggregation of
+  // client-side metrics.
+  temporalityPreference: AggregationTemporalityPreference.DELTA,
 });
 
 type Post = {

--- a/packages/exporter-otlp-http/src/index.ts
+++ b/packages/exporter-otlp-http/src/index.ts
@@ -1,8 +1,4 @@
 import {
-  AggregationTemporality,
-  PeriodicExportingMetricReader,
-} from "@opentelemetry/sdk-metrics";
-import {
   AggregationTemporalityPreference,
   OTLPMetricExporter,
 } from "@opentelemetry/exporter-metrics-otlp-http";
@@ -12,8 +8,11 @@ import {
   createDefaultBuildInfo,
   recordBuildInfo,
 } from "@autometrics/autometrics";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
 import { registerExporterInternal } from "./registerExporterInternal";
+
+export { AggregationTemporalityPreference };
 
 export type InitOptions = {
   /**
@@ -52,11 +51,9 @@ export type InitOptions = {
    * The aggregation temporality preference.
    *
    * By default, we use `AggregationTemporality.CUMULATIVE`. You may wish to
-   * change this depending on the OpenTelemetry Collector you use.
+   * change this depending on the setup you use.
    */
-  temporalityPreference?:
-    | AggregationTemporalityPreference
-    | AggregationTemporality;
+  temporalityPreference?: AggregationTemporalityPreference;
 
   /**
    * Optional build info to be added to the `build_info` metric.
@@ -73,7 +70,7 @@ export function init({
   pushInterval = 5000,
   concurrencyLimit,
   timeout = 1000,
-  temporalityPreference = AggregationTemporality.CUMULATIVE,
+  temporalityPreference = AggregationTemporalityPreference.CUMULATIVE,
   buildInfo,
 }: InitOptions) {
   amLogger.info(`Exporter will push to the OTLP/HTTP endpoint at ${url}`);


### PR DESCRIPTION
Also re-exports the `AggregationTemporalityPreference`, so people can directly use it.