### PR TITLE
Fix default prometheus exporter port

### DIFF
--- a/examples/express/src/server.ts
+++ b/examples/express/src/server.ts
@@ -10,7 +10,7 @@ import {
 } from "./routes.js";
 import { delay, generateRandomTraffic } from "./util.js";
 
-init(); // opens the `/metrics` endpoint on port 4964
+init(); // opens the `/metrics` endpoint on port 9464
 
 const app = express();
 

--- a/examples/fastify/src/index.ts
+++ b/examples/fastify/src/index.ts
@@ -3,7 +3,7 @@ import { autometrics } from "@autometrics/autometrics";
 import { init } from "@autometrics/exporter-prometheus";
 import { PrismaClient } from "@prisma/client";
 
-init(); // opens the `/metrics` endpoint on port 4964
+init(); // opens the `/metrics` endpoint on port 9464
 
 const port = 8080;
 const server = fastify();

--- a/examples/nestjs/src/main.ts
+++ b/examples/nestjs/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from "@nestjs/core";
 import { init } from "@autometrics/exporter-prometheus";
 import { AppModule } from "./app.module";
 
-init(); // opens the `/metrics` endpoint on port 4964
+init(); // opens the `/metrics` endpoint on port 9464
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/packages/autometrics/README.md
+++ b/packages/autometrics/README.md
@@ -30,7 +30,7 @@ pnpm add @autometrics/autometrics @autometrics/exporter-prometheus
 import { autometrics } from "@autometrics/autometrics";
 import { init } from "@autometrics/exporter-prometheus";
 
-init(); // starts the webserver with the `/metrics` endpoint on port 4964
+init(); // starts the webserver with the `/metrics` endpoint on port 9464
 
 async function createUserRaw(payload: User) {
   // ...

--- a/packages/exporter-prometheus/README.md
+++ b/packages/exporter-prometheus/README.md
@@ -2,7 +2,7 @@
 
 Export metrics by opening up a Prometheus scrape endpoint.
 
-This package will start a webserver on port 4964, by default, with a
+This package will start a webserver on port 9464, by default, with a
 Prometheus-compatible `/metrics` endpoint.
 
 You should configure your Prometheus instance to scrape this endpoint. For
@@ -35,7 +35,7 @@ pnpm add @autometrics/autometrics @autometrics/exporter-prometheus
 import { autometrics } from "@autometrics/autometrics";
 import { init } from "@autometrics/exporter-prometheus";
 
-init(); // starts the webserver with the `/metrics` endpoint on port 4964
+init(); // starts the webserver with the `/metrics` endpoint on port 9464
 
 async function createUserRaw(payload: User) {
   // ...

--- a/packages/exporter-prometheus/src/index.ts
+++ b/packages/exporter-prometheus/src/index.ts
@@ -14,7 +14,7 @@ export type InitOptions = {
   buildInfo?: BuildInfo;
 
   /**
-   * Port on which to open the Prometheus scrape endpoint (default: 4964).
+   * Port on which to open the Prometheus scrape endpoint (default: 9464).
    */
   port?: number;
 };
@@ -25,7 +25,7 @@ export type InitOptions = {
  * This opens up a webserver with the `/metrics` endpoint, to be scraped by
  * Prometheus.
  */
-export function init({ buildInfo, port }: InitOptions = {}) {
+export function init({ buildInfo, port = 9464 }: InitOptions = {}) {
   amLogger.info(`Opening a Prometheus scrape endpoint at port ${port}`);
 
   registerExporter({ metricReader: new PrometheusExporter({ port }) });


### PR DESCRIPTION
The `PrometheusExporter` from `"@opentelemetry/exporter-prometheus"` uses port `9464` as a default. 

I've updated our examples, docs, and prometheus exporter library to reflect that default. 

