### PR TITLE
Patch TypeScript plugin 

### DIFF
--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autometrics/typescript-plugin",
-  "version": "0.6.0-beta",
+  "version": "0.6.0-beta1",
   "description": "Language service plugin for Autometrics",
   "author": "Fiberplane<info@fiberplane.com>",
   "contributors": [

--- a/packages/typescript-plugin/src/astHelpers.ts
+++ b/packages/typescript-plugin/src/astHelpers.ts
@@ -20,7 +20,7 @@ export function isAutometricsWrappedOrDecorated(
   // Checks if the user is hovering over the autometrics wrapper itself in which
   // case we should not show the queries
   const isAutometricsWrapper =
-    typechecker.getTypeAtLocation(node)?.symbol?.getEscapedName() ===
+    typechecker.getTypeAtLocation(node)?.aliasSymbol?.getEscapedName() ===
     "autometrics";
 
   if (isAutometricsWrapper) {
@@ -35,7 +35,7 @@ export function isAutometricsWrappedOrDecorated(
       return;
     }
 
-    return typechecker.getTypeAtLocation(node)?.symbol?.getEscapedName();
+    return typechecker.getTypeAtLocation(node)?.aliasSymbol?.getEscapedName();
   };
 
   const type = checkWrapperType(node);

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -52,9 +52,6 @@ function init(modules: { typescript: Tsserver }) {
       }
 
       const nodeType = getNodeType(nodeAtCursor, typechecker, ts);
-      if (!nodeType) {
-        return prior;
-      }
 
       const autometrics = isAutometricsWrappedOrDecorated(
         nodeAtCursor,

--- a/packages/typescript-plugin/src/types/nodeType.ts
+++ b/packages/typescript-plugin/src/types/nodeType.ts
@@ -1,1 +1,1 @@
-export type NodeType = "function" | "method";
+export type NodeType = "function" | "method" | undefined;


### PR DESCRIPTION
This is a patch for a couple of issues that made TypeScript plugin render empty quick info tooltips.

Note: this is a hotfix intended to be published under the `beta` tag and warrants a thorough revision before going into the general release