### PR TITLE
Add caller.function and caller.module labels

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,7 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentSize": 2
+    "indentWidth": 2
   },
   "organizeImports": {
     "enabled": true

--- a/examples/express/tests/callerInfo.test.ts
+++ b/examples/express/tests/callerInfo.test.ts
@@ -26,7 +26,7 @@ test("Caller info test", async (t) => {
       );
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/express\/tests\/callerInfo.test.ts"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/dist\/tests\/callerInfo.test.js"\S*\} 1/gm,
       );
     },
   );
@@ -53,7 +53,7 @@ test("Caller info test", async (t) => {
       );
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/express\/tests\/callerInfo.test.ts"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/dist\/tests\/callerInfo.test.js"\S*\} 1/gm,
       );
     },
   );

--- a/examples/express/tests/callerInfo.test.ts
+++ b/examples/express/tests/callerInfo.test.ts
@@ -22,11 +22,11 @@ test("Caller info test", async (t) => {
 
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/express\/tests\/callerInfo.test.ts"\S*\} 1/gm,
       );
     },
   );
@@ -49,11 +49,11 @@ test("Caller info test", async (t) => {
 
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/express\/tests\/callerInfo.test.ts"\S*\} 1/gm,
       );
     },
   );

--- a/examples/hono-bun/tests/callerInfo.test.ts
+++ b/examples/hono-bun/tests/callerInfo.test.ts
@@ -20,7 +20,7 @@ test("Caller info test -- synchronous call", async () => {
       /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
     );
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/hono-bun\/tests\/callerInfo.test.ts"\S*\} 1/gm,
+      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/tests\/callerInfo.test.ts"\S*\} 1/gm,
     );
   });
 });
@@ -43,7 +43,7 @@ test("Caller info test -- asynchronous call", async () => {
       /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
     );
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/hono-bun\/tests\/callerInfo.test.ts"\S*\} 1/gm,
+      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/tests\/callerInfo.test.ts"\S*\} 1/gm,
     );
   });
 });

--- a/examples/hono-bun/tests/callerInfo.test.ts
+++ b/examples/hono-bun/tests/callerInfo.test.ts
@@ -17,10 +17,10 @@ test("Caller info test -- synchronous call", async () => {
     const serialized = await collectAndSerialize(metricReader);
 
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
     );
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/hono-bun\/tests\/callerInfo.test.ts"\S*\} 1/gm,
     );
   });
 });
@@ -40,10 +40,10 @@ test("Caller info test -- asynchronous call", async () => {
     const serialized = await collectAndSerialize(metricReader);
 
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
     );
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/examples\/hono-bun\/tests\/callerInfo.test.ts"\S*\} 1/gm,
     );
   });
 });

--- a/packages/autometrics/src/platform.deno.ts
+++ b/packages/autometrics/src/platform.deno.ts
@@ -43,7 +43,7 @@ export function getCwd(): string {
  *
  * @internal
  */
-export type AsyncContext = { caller?: string };
+export type AsyncContext = { callerFunction?: string; callerModule?: string };
 
 /**
  * Returns a new `AsyncLocalStorage` instance for storing caller information.

--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -58,5 +58,8 @@ export function getCwd(): string {
  * @internal
  */
 export function getALSInstance() {
-  return new AsyncLocalStorage<{ callerFunction?: string, callerModule?: string }>();
+  return new AsyncLocalStorage<{
+    callerFunction?: string;
+    callerModule?: string;
+  }>();
 }

--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -58,5 +58,5 @@ export function getCwd(): string {
  * @internal
  */
 export function getALSInstance() {
-  return new AsyncLocalStorage<{ caller?: string }>();
+  return new AsyncLocalStorage<{ callerFunction?: string, callerModule?: string }>();
 }

--- a/packages/autometrics/src/wrappers.ts
+++ b/packages/autometrics/src/wrappers.ts
@@ -9,11 +9,11 @@ import {
   HISTOGRAM_DESCRIPTION,
   HISTOGRAM_NAME,
 } from "./constants.ts";
-import { getALSInstance } from "./platform.deno.ts";
 import { getMeter, metricsRecorded } from "./instrumentation.ts";
-import { getModulePath, isFunction, isObject, isPromise } from "./utils.ts";
 import { trace, warn } from "./logger.ts";
 import type { Objective } from "./objectives.ts";
+import { getALSInstance } from "./platform.deno.ts";
+import { getModulePath, isFunction, isObject, isPromise } from "./utils.ts";
 
 const asyncLocalStorage = getALSInstance();
 

--- a/packages/autometrics/src/wrappers.ts
+++ b/packages/autometrics/src/wrappers.ts
@@ -296,15 +296,9 @@ export function autometrics<F extends FunctionSig>(
       module: moduleName,
     });
 
-    let callerFunction: string;
-    let callerModule: string;
-
-    const callerData = asyncLocalStorage?.getStore() ?? "";
-
-    if (callerData !== "") {
-      callerFunction = callerData.callerFunction ?? "";
-      callerModule = callerData.callerModule ?? "";
-    }
+    const callerData = asyncLocalStorage?.getStore();
+    const callerFunction = callerData?.callerFunction ?? "";
+    const callerModule = callerData?.callerModule ?? "";
 
     const onSuccess = () => {
       const autometricsDuration = (performance.now() - autometricsStart) / 1000;

--- a/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
+++ b/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
@@ -2,7 +2,8 @@ export const snapshot = {};
 
 snapshot[`OTLP/HTTP exporter 1`] = `
 {
-  caller: "",
+  caller_function: "",
+  caller_module: "",
   function: "foo",
   module: "/packages/autometrics/tests/otlpHttpExporter.test.ts",
   objective_name: "",

--- a/packages/autometrics/tests/callerInfo.test.ts
+++ b/packages/autometrics/tests/callerInfo.test.ts
@@ -21,11 +21,11 @@ Deno.test("Caller info test", async (t) => {
 
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/packages\/autometrics\/tests\/callerInfo.test.ts"\S*\} 1/gm,
       );
     },
   );
@@ -48,11 +48,11 @@ Deno.test("Caller info test", async (t) => {
 
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/packages\/autometrics\/tests\/callerInfo.test.ts"\S*\} 1/gm,
       );
     },
   );


### PR DESCRIPTION
This PR updates the library so it correctly reports the `caller_function` and `caller_module` information as per spec.
