### PR TITLE
Support web builds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "deno.lint": false,
   "deno.unstable": false,
   "deno.disablePaths": [
+    "dist",
     "examples/express",
     "examples/faas-experimental",
     "examples/fastify",

--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,7 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentSize": 2
+    "indentWidth": 2
   },
   "organizeImports": {
     "enabled": true

--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
     "$otel/exporter-metrics-otlp-http": "npm:@opentelemetry/exporter-metrics-otlp-http@^0.43.0",
     "$otel/exporter-prometheus": "npm:@opentelemetry/exporter-prometheus@^0.43.0",
     "$otel/resources": "npm:@opentelemetry/resources@^1.17.0",
-    "$otel/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.17.0"
+    "$otel/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.17.0",
+    "node-fetch-native": "npm:node-fetch-native@^1.4.1"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,12 @@
     "strict": true
   },
   "imports": {
-    "$std/": "https://deno.land/std@0.203.0/"
+    "$std/": "https://deno.land/std@0.203.0/",
+    "$otel/api": "npm:@opentelemetry/api@^1.6.0",
+    "$otel/core": "npm:@opentelemetry/core@^1.17.0",
+    "$otel/exporter-metrics-otlp-http": "npm:@opentelemetry/exporter-metrics-otlp-http@^0.43.0",
+    "$otel/exporter-prometheus": "npm:@opentelemetry/exporter-prometheus@^0.43.0",
+    "$otel/resources": "npm:@opentelemetry/resources@^1.17.0",
+    "$otel/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.17.0"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -12,10 +12,12 @@
       "npm:@types/express@4.17.18": "npm:@types/express@4.17.18",
       "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:express@4.18.2": "npm:express@4.18.2",
+      "npm:node-fetch-native@1.4.1": "npm:node-fetch-native@1.4.1",
       "npm:rollup-plugin-alias": "npm:rollup-plugin-alias@2.2.0",
       "npm:rollup-plugin-dts": "npm:rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2",
       "npm:rollup-plugin-dts@6.1.0": "npm:rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2",
       "npm:rollup-plugin-swc3@0.10.3": "npm:rollup-plugin-swc3@0.10.3_@swc+core@1.3.93_rollup@4.1.4",
+      "npm:rollup-plugin-ts@3.4.5": "npm:rollup-plugin-ts@3.4.5_rollup@3.29.4_typescript@5.2.2",
       "npm:rollup@3.29.4": "npm:rollup@3.29.4"
     },
     "npm": {
@@ -44,6 +46,10 @@
       },
       "@jridgewell/sourcemap-codec@1.4.15": {
         "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+        "dependencies": {}
+      },
+      "@mdn/browser-compat-data@5.3.27": {
+        "integrity": "sha512-ts9LDUeckWeHVjGR3uk70/pm1yuwvl/bawPGsOittOk95YRkutuGvnRrfl2lARd0XrCNIIFwRZsmw2pVjMaNJw==",
         "dependencies": {}
       },
       "@napi-rs/magic-string-android-arm-eabi@0.3.4": {
@@ -218,6 +224,15 @@
           "slash": "slash@4.0.0"
         }
       },
+      "@rollup/pluginutils@5.0.5_rollup@3.29.4": {
+        "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+        "dependencies": {
+          "@types/estree": "@types/estree@1.0.3",
+          "estree-walker": "estree-walker@2.0.2",
+          "picomatch": "picomatch@2.3.1",
+          "rollup": "rollup@3.29.4"
+        }
+      },
       "@rollup/pluginutils@5.0.5_rollup@4.1.4": {
         "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
         "dependencies": {
@@ -387,8 +402,16 @@
         "integrity": "sha512-Wj+fqpTLtTbG7c0tH47dkahefpLKEbB+xAZuLq7b4/IDHPl/n6VoXcyUQ2bypFlbSwvCr0y+bD4euTTqTJsPxQ==",
         "dependencies": {}
       },
+      "@types/node@17.0.45": {
+        "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+        "dependencies": {}
+      },
       "@types/node@18.16.19": {
         "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+        "dependencies": {}
+      },
+      "@types/object-path@0.11.3": {
+        "integrity": "sha512-P6V8jUKl0qA/U5ZAWW1y/BxeFf/R3yZucVGnHtD1qRXmFPndKZK4iZ49qX73R0FIwZnk0yKYixmqtYrPtManaA==",
         "dependencies": {}
       },
       "@types/qs@6.9.8": {
@@ -397,6 +420,10 @@
       },
       "@types/range-parser@1.2.5": {
         "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+        "dependencies": {}
+      },
+      "@types/semver@7.5.4": {
+        "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
         "dependencies": {}
       },
       "@types/send@0.17.2": {
@@ -414,12 +441,24 @@
           "@types/node": "@types/node@18.16.19"
         }
       },
+      "@types/ua-parser-js@0.7.38": {
+        "integrity": "sha512-59CA5oavBEWSNLtS/BChj9xntiWMsIf9IytjxmBo9OuZEYuRzRf3K1ARzFPlXTOz5Zm2wXI38AP9RlLqDYMToQ==",
+        "dependencies": {}
+      },
+      "@wessberg/stringutil@1.0.19": {
+        "integrity": "sha512-9AZHVXWlpN8Cn9k5BC/O0Dzb9E9xfEMXzYrNunwvkUTvuK7xgQPVRZpLo+jWCOZ5r8oBa8NIrHuPEu1hzbb6bg==",
+        "dependencies": {}
+      },
       "accepts@1.3.8": {
         "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
         "dependencies": {
           "mime-types": "mime-types@2.1.35",
           "negotiator": "negotiator@0.6.3"
         }
+      },
+      "ansi-colors@4.1.3": {
+        "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+        "dependencies": {}
       },
       "ansi-styles@3.2.1": {
         "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
@@ -448,6 +487,30 @@
           "unpipe": "unpipe@1.0.0"
         }
       },
+      "browserslist-generator@2.1.0": {
+        "integrity": "sha512-ZFz4mAOgqm0cbwKaZsfJbYDbTXGoPANlte7qRsRJOfjB9KmmISQrXJxAVrnXG8C8v/QHNzXyeJt0Cfcks6zZvQ==",
+        "dependencies": {
+          "@mdn/browser-compat-data": "@mdn/browser-compat-data@5.3.27",
+          "@types/object-path": "@types/object-path@0.11.3",
+          "@types/semver": "@types/semver@7.5.4",
+          "@types/ua-parser-js": "@types/ua-parser-js@0.7.38",
+          "browserslist": "browserslist@4.22.1",
+          "caniuse-lite": "caniuse-lite@1.0.30001551",
+          "isbot": "isbot@3.7.0",
+          "object-path": "object-path@0.11.8",
+          "semver": "semver@7.5.4",
+          "ua-parser-js": "ua-parser-js@1.0.37"
+        }
+      },
+      "browserslist@4.22.1": {
+        "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+        "dependencies": {
+          "caniuse-lite": "caniuse-lite@1.0.30001551",
+          "electron-to-chromium": "electron-to-chromium@1.4.561",
+          "node-releases": "node-releases@2.0.13",
+          "update-browserslist-db": "update-browserslist-db@1.0.13_browserslist@4.22.1"
+        }
+      },
       "bytes@3.1.2": {
         "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
         "dependencies": {}
@@ -458,6 +521,10 @@
           "function-bind": "function-bind@1.1.1",
           "get-intrinsic": "get-intrinsic@1.2.1"
         }
+      },
+      "caniuse-lite@1.0.30001551": {
+        "integrity": "sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==",
+        "dependencies": {}
       },
       "chalk@2.4.2": {
         "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
@@ -477,6 +544,13 @@
         "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
         "dependencies": {}
       },
+      "compatfactory@3.0.0_typescript@5.2.2": {
+        "integrity": "sha512-WD5kF7koPwVoyKL8p0LlrmIZtilrD46sQStyzzxzTFinMKN2Dxk1hN+sddLSQU1mGIZvQfU8c+ONSghvvM40jg==",
+        "dependencies": {
+          "helpertypes": "helpertypes@0.0.19",
+          "typescript": "typescript@5.2.2"
+        }
+      },
       "content-disposition@0.5.4": {
         "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
         "dependencies": {
@@ -494,6 +568,12 @@
       "cookie@0.5.0": {
         "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
         "dependencies": {}
+      },
+      "crosspath@2.0.0": {
+        "integrity": "sha512-ju88BYCQ2uvjO2bR+SsgLSTwTSctU+6Vp2ePbKPgSCZyy4MWZxYsT738DlKVRE5utUjobjPRm1MkTYKJxCmpTA==",
+        "dependencies": {
+          "@types/node": "@types/node@17.0.45"
+        }
       },
       "debug@2.6.9": {
         "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
@@ -513,8 +593,16 @@
         "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
         "dependencies": {}
       },
+      "electron-to-chromium@1.4.561": {
+        "integrity": "sha512-eS5t4ulWOBfVHdq9SW2dxEaFarj1lPjvJ8PaYMOjY0DecBaj/t4ARziL2IPpDr4atyWwjLFGQ2vo/VCgQFezVQ==",
+        "dependencies": {}
+      },
       "encodeurl@1.0.2": {
         "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+        "dependencies": {}
+      },
+      "escalade@3.1.1": {
+        "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
         "dependencies": {}
       },
       "escape-html@1.0.3": {
@@ -630,6 +718,10 @@
           "function-bind": "function-bind@1.1.1"
         }
       },
+      "helpertypes@0.0.19": {
+        "integrity": "sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==",
+        "dependencies": {}
+      },
       "http-errors@2.0.0": {
         "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
         "dependencies": {
@@ -654,6 +746,10 @@
         "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
         "dependencies": {}
       },
+      "isbot@3.7.0": {
+        "integrity": "sha512-9BcjlI89966BqWJmYdTnRub85sit931MyCthSIPtgoOsTjoW7A2MVa09HzPpYE2+G4vyAxfDvR0AbUGV0FInQg==",
+        "dependencies": {}
+      },
       "js-tokens@4.0.0": {
         "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
         "dependencies": {}
@@ -661,6 +757,12 @@
       "lodash.merge@4.6.2": {
         "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
         "dependencies": {}
+      },
+      "lru-cache@6.0.0": {
+        "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+        "dependencies": {
+          "yallist": "yallist@4.0.0"
+        }
       },
       "magic-string@0.30.5": {
         "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
@@ -706,8 +808,20 @@
         "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
         "dependencies": {}
       },
+      "node-fetch-native@1.4.1": {
+        "integrity": "sha512-NsXBU0UgBxo2rQLOeWNZqS3fvflWePMECr8CoSWoSTqCqGbVVsvl9vZu1HfQicYN0g5piV9Gh8RTEvo/uP752w==",
+        "dependencies": {}
+      },
+      "node-releases@2.0.13": {
+        "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+        "dependencies": {}
+      },
       "object-inspect@1.12.3": {
         "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+        "dependencies": {}
+      },
+      "object-path@0.11.8": {
+        "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
         "dependencies": {}
       },
       "on-finished@2.4.1": {
@@ -722,6 +836,10 @@
       },
       "path-to-regexp@0.1.7": {
         "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+        "dependencies": {}
+      },
+      "picocolors@1.0.0": {
+        "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
         "dependencies": {}
       },
       "picomatch@2.3.1": {
@@ -784,6 +902,23 @@
           "rollup-swc-preserve-directives": "rollup-swc-preserve-directives@0.5.0_@swc+core@1.3.93_rollup@3.29.4"
         }
       },
+      "rollup-plugin-ts@3.4.5_rollup@3.29.4_typescript@5.2.2": {
+        "integrity": "sha512-9iCstRJpEZXSRQuXitlSZAzcGlrqTbJg1pE4CMbEi6xYldxVncdPyzA2I+j6vnh73wBymZckerS+Q/iEE/M3Ow==",
+        "dependencies": {
+          "@rollup/pluginutils": "@rollup/pluginutils@5.0.5_rollup@3.29.4",
+          "@wessberg/stringutil": "@wessberg/stringutil@1.0.19",
+          "ansi-colors": "ansi-colors@4.1.3",
+          "browserslist": "browserslist@4.22.1",
+          "browserslist-generator": "browserslist-generator@2.1.0",
+          "compatfactory": "compatfactory@3.0.0_typescript@5.2.2",
+          "crosspath": "crosspath@2.0.0",
+          "magic-string": "magic-string@0.30.5",
+          "rollup": "rollup@3.29.4",
+          "ts-clone-node": "ts-clone-node@3.0.0_typescript@5.2.2",
+          "tslib": "tslib@2.6.2",
+          "typescript": "typescript@5.2.2"
+        }
+      },
       "rollup-swc-preserve-directives@0.5.0_@swc+core@1.3.93_rollup@3.29.4": {
         "integrity": "sha512-6lnPZn2laSsdYcdCSE28z4Dwg2mCN5loF+/wBjybh25GJmONjHTf3orWa5j1zjEWY3RcGRjJ8K/52ePqtfy6dw==",
         "dependencies": {
@@ -823,6 +958,12 @@
       "safer-buffer@2.1.2": {
         "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
         "dependencies": {}
+      },
+      "semver@7.5.4": {
+        "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+        "dependencies": {
+          "lru-cache": "lru-cache@6.0.0"
+        }
       },
       "send@0.18.0": {
         "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
@@ -885,6 +1026,17 @@
         "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
         "dependencies": {}
       },
+      "ts-clone-node@3.0.0_typescript@5.2.2": {
+        "integrity": "sha512-egavvyHbIoelkgh1IC2agNB1uMNjB8VJgh0g/cn0bg2XXTcrtjrGMzEk4OD3Fi2hocICjP3vMa56nkzIzq0FRg==",
+        "dependencies": {
+          "compatfactory": "compatfactory@3.0.0_typescript@5.2.2",
+          "typescript": "typescript@5.2.2"
+        }
+      },
+      "tslib@2.6.2": {
+        "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+        "dependencies": {}
+      },
       "type-is@1.6.18": {
         "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
         "dependencies": {
@@ -896,9 +1048,21 @@
         "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
         "dependencies": {}
       },
+      "ua-parser-js@1.0.37": {
+        "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
+        "dependencies": {}
+      },
       "unpipe@1.0.0": {
         "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
         "dependencies": {}
+      },
+      "update-browserslist-db@1.0.13_browserslist@4.22.1": {
+        "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+        "dependencies": {
+          "browserslist": "browserslist@4.22.1",
+          "escalade": "escalade@3.1.1",
+          "picocolors": "picocolors@1.0.0"
+        }
       },
       "utils-merge@1.0.1": {
         "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
@@ -906,6 +1070,10 @@
       },
       "vary@1.1.2": {
         "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+        "dependencies": {}
+      },
+      "yallist@4.0.0": {
+        "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
         "dependencies": {}
       }
     }

--- a/deno.lock
+++ b/deno.lock
@@ -8,16 +8,12 @@
       "npm:@opentelemetry/exporter-prometheus@^0.43.0": "npm:@opentelemetry/exporter-prometheus@0.43.0_@opentelemetry+api@1.6.0",
       "npm:@opentelemetry/resources@^1.17.0": "npm:@opentelemetry/resources@1.17.0_@opentelemetry+api@1.6.0",
       "npm:@opentelemetry/sdk-metrics@^1.17.0": "npm:@opentelemetry/sdk-metrics@1.17.0_@opentelemetry+api@1.6.0",
-      "npm:@rollup/plugin-alias@5.0.1": "npm:@rollup/plugin-alias@5.0.1_rollup@3.29.4",
       "npm:@types/express@4.17.18": "npm:@types/express@4.17.18",
       "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:express@4.18.2": "npm:express@4.18.2",
       "npm:node-fetch-native@1.4.1": "npm:node-fetch-native@1.4.1",
-      "npm:rollup-plugin-alias": "npm:rollup-plugin-alias@2.2.0",
-      "npm:rollup-plugin-dts": "npm:rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2",
       "npm:rollup-plugin-dts@6.1.0": "npm:rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2",
       "npm:rollup-plugin-swc3@0.10.3": "npm:rollup-plugin-swc3@0.10.3_@swc+core@1.3.93_rollup@4.1.4",
-      "npm:rollup-plugin-ts@3.4.5": "npm:rollup-plugin-ts@3.4.5_rollup@3.29.4_typescript@5.2.2",
       "npm:rollup@3.29.4": "npm:rollup@3.29.4"
     },
     "npm": {

--- a/deno.lock
+++ b/deno.lock
@@ -8,11 +8,114 @@
       "npm:@opentelemetry/exporter-prometheus@^0.43.0": "npm:@opentelemetry/exporter-prometheus@0.43.0_@opentelemetry+api@1.6.0",
       "npm:@opentelemetry/resources@^1.17.0": "npm:@opentelemetry/resources@1.17.0_@opentelemetry+api@1.6.0",
       "npm:@opentelemetry/sdk-metrics@^1.17.0": "npm:@opentelemetry/sdk-metrics@1.17.0_@opentelemetry+api@1.6.0",
+      "npm:@rollup/plugin-alias@5.0.1": "npm:@rollup/plugin-alias@5.0.1_rollup@3.29.4",
       "npm:@types/express@4.17.18": "npm:@types/express@4.17.18",
       "npm:@types/node": "npm:@types/node@18.16.19",
-      "npm:express@4.18.2": "npm:express@4.18.2"
+      "npm:express@4.18.2": "npm:express@4.18.2",
+      "npm:rollup-plugin-alias": "npm:rollup-plugin-alias@2.2.0",
+      "npm:rollup-plugin-dts": "npm:rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2",
+      "npm:rollup-plugin-dts@6.1.0": "npm:rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2",
+      "npm:rollup-plugin-swc3@0.10.3": "npm:rollup-plugin-swc3@0.10.3_@swc+core@1.3.93_rollup@4.1.4",
+      "npm:rollup@3.29.4": "npm:rollup@3.29.4"
     },
     "npm": {
+      "@babel/code-frame@7.22.13": {
+        "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+        "dependencies": {
+          "@babel/highlight": "@babel/highlight@7.22.20",
+          "chalk": "chalk@2.4.2"
+        }
+      },
+      "@babel/helper-validator-identifier@7.22.20": {
+        "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+        "dependencies": {}
+      },
+      "@babel/highlight@7.22.20": {
+        "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+        "dependencies": {
+          "@babel/helper-validator-identifier": "@babel/helper-validator-identifier@7.22.20",
+          "chalk": "chalk@2.4.2",
+          "js-tokens": "js-tokens@4.0.0"
+        }
+      },
+      "@fastify/deepmerge@1.3.0": {
+        "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+        "dependencies": {}
+      },
+      "@jridgewell/sourcemap-codec@1.4.15": {
+        "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-android-arm-eabi@0.3.4": {
+        "integrity": "sha512-sszAYxqtzzJ4FDerDNHcqL9NhqPhj8W4DNiOanXYy50mA5oojlRtaAFPiB5ZMrWDBM32v5Q30LrmxQ4eTtu2Dg==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-android-arm64@0.3.4": {
+        "integrity": "sha512-jdQ6HuO0X5rkX4MauTcWR4HWdgjakTOmmzqXg8L26+jOHVVG1LZE+Su5qvV4bP8vMb2h+vPE+JsnwqSmWymu3Q==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-darwin-arm64@0.3.4": {
+        "integrity": "sha512-6NmMtvURce9/oq09XBZmuIeI6lPLGtEJ2ZPO/QzL3nLZa6wygiCnO/sFACKYNg5/73ET5HMMTeuogE1JI+r2Lw==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-darwin-x64@0.3.4": {
+        "integrity": "sha512-f9LmfMiUAKDOtl0meOuLYeVb6OERrgGzrTg1Tn3R3fTAShM2kxRbfAuPE9ljuXxIFzOv/uqRNLSl/LqCJwpREA==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-freebsd-x64@0.3.4": {
+        "integrity": "sha512-rqduQ4odiDK4QdM45xHWRTU4wtFIfpp8g8QGpz+3qqg7ivldDqbbNOrBaf6Oeu77uuEvWggnkyuChotfKgJdJQ==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-linux-arm-gnueabihf@0.3.4": {
+        "integrity": "sha512-pVaJEdEpiPqIfq3M4+yMAATS7Z9muDcWYn8H7GFH1ygh8GwgLgKfy/n/lG2M6zp18Mwd0x7E2E/qg9GgCyUzoQ==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-linux-arm64-gnu@0.3.4": {
+        "integrity": "sha512-9FwoAih/0tzEZx0BjYYIxWkSRMjonIn91RFM3q3MBs/evmThXUYXUqLNa1PPIkK1JoksswtDi48qWWLt8nGflQ==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-linux-arm64-musl@0.3.4": {
+        "integrity": "sha512-wCR7R+WPOcAKmVQc1s6h6HwfwW1vL9pM8BjUY9Ljkdb8wt1LmZEmV2Sgfc1SfbRQzbyl+pKeufP6adRRQVzYDA==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-linux-x64-gnu@0.3.4": {
+        "integrity": "sha512-sbxFDpYnt5WFbxQ1xozwOvh5A7IftqSI0WnE9O7KsQIOi0ej2dvFbfOW4tmFkvH/YP8KJELo5AhP2+kEq1DpYA==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-linux-x64-musl@0.3.4": {
+        "integrity": "sha512-jN4h/7e2Ul8v3UK5IZu38NXLMdzVWhY4uEDlnwuUAhwRh26wBQ1/pLD97Uy/Z3dFNBQPcsv60XS9fOM1YDNT6w==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-win32-arm64-msvc@0.3.4": {
+        "integrity": "sha512-gMUyTRHLWpzX2ntJFCbW2Gnla9Y/WUmbkZuW5SBAo/Jo8QojHn76Y4PNgnoXdzcsV9b/45RBxurYKAfFg9WTyg==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-win32-ia32-msvc@0.3.4": {
+        "integrity": "sha512-QIMauMOvEHgL00K9np/c9CT/CRtLOz3mRTQqcZ9XGzSoAMrpxH71KSpDJrKl7h7Ro6TZ+hJ0C3T+JVuTCZNv4A==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string-win32-x64-msvc@0.3.4": {
+        "integrity": "sha512-V8FMSf828MzOI3P6/765MR7zHU6CUZqiyPhmAnwYoKFNxfv7oCviN/G6NcENeCdcYOvNgh5fYzaNLB96ndId5A==",
+        "dependencies": {}
+      },
+      "@napi-rs/magic-string@0.3.4": {
+        "integrity": "sha512-DEWl/B99RQsyMT3F9bvrXuhL01/eIQp/dtNSE3G1jQ4mTGRcP4iHWxoPZ577WrbjUinrNgvRA5+08g8fkPgimQ==",
+        "dependencies": {
+          "@napi-rs/magic-string-android-arm-eabi": "@napi-rs/magic-string-android-arm-eabi@0.3.4",
+          "@napi-rs/magic-string-android-arm64": "@napi-rs/magic-string-android-arm64@0.3.4",
+          "@napi-rs/magic-string-darwin-arm64": "@napi-rs/magic-string-darwin-arm64@0.3.4",
+          "@napi-rs/magic-string-darwin-x64": "@napi-rs/magic-string-darwin-x64@0.3.4",
+          "@napi-rs/magic-string-freebsd-x64": "@napi-rs/magic-string-freebsd-x64@0.3.4",
+          "@napi-rs/magic-string-linux-arm-gnueabihf": "@napi-rs/magic-string-linux-arm-gnueabihf@0.3.4",
+          "@napi-rs/magic-string-linux-arm64-gnu": "@napi-rs/magic-string-linux-arm64-gnu@0.3.4",
+          "@napi-rs/magic-string-linux-arm64-musl": "@napi-rs/magic-string-linux-arm64-musl@0.3.4",
+          "@napi-rs/magic-string-linux-x64-gnu": "@napi-rs/magic-string-linux-x64-gnu@0.3.4",
+          "@napi-rs/magic-string-linux-x64-musl": "@napi-rs/magic-string-linux-x64-musl@0.3.4",
+          "@napi-rs/magic-string-win32-arm64-msvc": "@napi-rs/magic-string-win32-arm64-msvc@0.3.4",
+          "@napi-rs/magic-string-win32-ia32-msvc": "@napi-rs/magic-string-win32-ia32-msvc@0.3.4",
+          "@napi-rs/magic-string-win32-x64-msvc": "@napi-rs/magic-string-win32-x64-msvc@0.3.4"
+        }
+      },
       "@opentelemetry/api-logs@0.43.0": {
         "integrity": "sha512-0CXMOYPXgAdLM2OzVkiUfAL6QQwWVhnMfUXCqLsITY42FZ9TxAhZIHkoc4mfVxvPuXsBnRYGR8UQZX86p87z4A==",
         "dependencies": {
@@ -108,6 +211,135 @@
         "integrity": "sha512-+fguCd2d8d2qruk0H0DsCEy2CTK3t0Tugg7MhZ/UQMvmewbZLNnJ6heSYyzIZWG5IPfAXzoj4f4F/qpM7l4VBA==",
         "dependencies": {}
       },
+      "@rollup/plugin-alias@5.0.1_rollup@3.29.4": {
+        "integrity": "sha512-JObvbWdOHoMy9W7SU0lvGhDtWq9PllP5mjpAy+TUslZG/WzOId9u80Hsqq1vCUn9pFJ0cxpdcnAv+QzU2zFH3Q==",
+        "dependencies": {
+          "rollup": "rollup@3.29.4",
+          "slash": "slash@4.0.0"
+        }
+      },
+      "@rollup/pluginutils@5.0.5_rollup@4.1.4": {
+        "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+        "dependencies": {
+          "@types/estree": "@types/estree@1.0.3",
+          "estree-walker": "estree-walker@2.0.2",
+          "picomatch": "picomatch@2.3.1",
+          "rollup": "rollup@4.1.4"
+        }
+      },
+      "@rollup/rollup-android-arm-eabi@4.1.4": {
+        "integrity": "sha512-WlzkuFvpKl6CLFdc3V6ESPt7gq5Vrimd2Yv9IzKXdOpgbH4cdDSS1JLiACX8toygihtH5OlxyQzhXOph7Ovlpw==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-android-arm64@4.1.4": {
+        "integrity": "sha512-D1e+ABe56T9Pq2fD+R3ybe1ylCDzu3tY4Qm2Mj24R9wXNCq35+JbFbOpc2yrroO2/tGhTobmEl2Bm5xfE/n8RA==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-darwin-arm64@4.1.4": {
+        "integrity": "sha512-7vTYrgEiOrjxnjsgdPB+4i7EMxbVp7XXtS+50GJYj695xYTTEMn3HZVEvgtwjOUkAP/Q4HDejm4fIAjLeAfhtg==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-darwin-x64@4.1.4": {
+        "integrity": "sha512-eGJVZScKSLZkYjhTAESCtbyTBq9SXeW9+TX36ki5gVhDqJtnQ5k0f9F44jNK5RhAMgIj0Ht9+n6HAgH0gUUyWQ==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-linux-arm-gnueabihf@4.1.4": {
+        "integrity": "sha512-HnigYSEg2hOdX1meROecbk++z1nVJDpEofw9V2oWKqOWzTJlJf1UXVbDE6Hg30CapJxZu5ga4fdAQc/gODDkKg==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-linux-arm64-gnu@4.1.4": {
+        "integrity": "sha512-TzJ+N2EoTLWkaClV2CUhBlj6ljXofaYzF/R9HXqQ3JCMnCHQZmQnbnZllw7yTDp0OG5whP4gIPozR4QiX+00MQ==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-linux-arm64-musl@4.1.4": {
+        "integrity": "sha512-aVPmNMdp6Dlo2tWkAduAD/5TL/NT5uor290YvjvFvCv0Q3L7tVdlD8MOGDL+oRSw5XKXKAsDzHhUOPUNPRHVTQ==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-linux-x64-gnu@4.1.4": {
+        "integrity": "sha512-77Fb79ayiDad0grvVsz4/OB55wJRyw9Ao+GdOBA9XywtHpuq5iRbVyHToGxWquYWlEf6WHFQQnFEttsAzboyKg==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-linux-x64-musl@4.1.4": {
+        "integrity": "sha512-/t6C6niEQTqmQTVTD9TDwUzxG91Mlk69/v0qodIPUnjjB3wR4UA3klg+orR2SU3Ux2Cgf2pWPL9utK80/1ek8g==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-win32-arm64-msvc@4.1.4": {
+        "integrity": "sha512-ZY5BHHrOPkMbCuGWFNpJH0t18D2LU6GMYKGaqaWTQ3CQOL57Fem4zE941/Ek5pIsVt70HyDXssVEFQXlITI5Gg==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-win32-ia32-msvc@4.1.4": {
+        "integrity": "sha512-XG2mcRfFrJvYyYaQmvCIvgfkaGinfXrpkBuIbJrTl9SaIQ8HumheWTIwkNz2mktCKwZfXHQNpO7RgXLIGQ7HXA==",
+        "dependencies": {}
+      },
+      "@rollup/rollup-win32-x64-msvc@4.1.4": {
+        "integrity": "sha512-ANFqWYPwkhIqPmXw8vm0GpBEHiPpqcm99jiiAp71DbCSqLDhrtr019C5vhD0Bw4My+LmMvciZq6IsWHqQpl2ZQ==",
+        "dependencies": {}
+      },
+      "@swc/core-darwin-arm64@1.3.93": {
+        "integrity": "sha512-gEKgk7FVIgltnIfDO6GntyuQBBlAYg5imHpRgLxB1zSI27ijVVkksc6QwISzFZAhKYaBWIsFSVeL9AYSziAF7A==",
+        "dependencies": {}
+      },
+      "@swc/core-darwin-x64@1.3.93": {
+        "integrity": "sha512-ZQPxm/fXdDQtn3yrYSL/gFfA8OfZ5jTi33yFQq6vcg/Y8talpZ+MgdSlYM0FkLrZdMTYYTNFiuBQuuvkA+av+Q==",
+        "dependencies": {}
+      },
+      "@swc/core-linux-arm-gnueabihf@1.3.93": {
+        "integrity": "sha512-OYFMMI2yV+aNe3wMgYhODxHdqUB/jrK0SEMHHS44GZpk8MuBXEF+Mcz4qjkY5Q1EH7KVQqXb/gVWwdgTHpjM2A==",
+        "dependencies": {}
+      },
+      "@swc/core-linux-arm64-gnu@1.3.93": {
+        "integrity": "sha512-BT4dT78odKnJMNiq5HdjBsv29CiIdcCcImAPxeFqAeFw1LL6gh9nzI8E96oWc+0lVT5lfhoesCk4Qm7J6bty8w==",
+        "dependencies": {}
+      },
+      "@swc/core-linux-arm64-musl@1.3.93": {
+        "integrity": "sha512-yH5fWEl1bktouC0mhh0Chuxp7HEO4uCtS/ly1Vmf18gs6wZ8DOOkgAEVv2dNKIryy+Na++ljx4Ym7C8tSJTrLw==",
+        "dependencies": {}
+      },
+      "@swc/core-linux-x64-gnu@1.3.93": {
+        "integrity": "sha512-OFUdx64qvrGJhXKEyxosHxgoUVgba2ztYh7BnMiU5hP8lbI8G13W40J0SN3CmFQwPP30+3oEbW7LWzhKEaYjlg==",
+        "dependencies": {}
+      },
+      "@swc/core-linux-x64-musl@1.3.93": {
+        "integrity": "sha512-4B8lSRwEq1XYm6xhxHhvHmKAS7pUp1Q7E33NQ2TlmFhfKvCOh86qvThcjAOo57x8DRwmpvEVrqvpXtYagMN6Ig==",
+        "dependencies": {}
+      },
+      "@swc/core-win32-arm64-msvc@1.3.93": {
+        "integrity": "sha512-BHShlxtkven8ZjjvZ5QR6sC5fZCJ9bMujEkiha6W4cBUTY7ce7qGFyHmQd+iPC85d9kD/0cCiX/Xez8u0BhO7w==",
+        "dependencies": {}
+      },
+      "@swc/core-win32-ia32-msvc@1.3.93": {
+        "integrity": "sha512-nEwNWnz4JzYAK6asVvb92yeylfxMYih7eMQOnT7ZVlZN5ba9WF29xJ6kcQKs9HRH6MvWhz9+wRgv3FcjlU6HYA==",
+        "dependencies": {}
+      },
+      "@swc/core-win32-x64-msvc@1.3.93": {
+        "integrity": "sha512-jibQ0zUr4kwJaQVwgmH+svS04bYTPnPw/ZkNInzxS+wFAtzINBYcU8s2PMWbDb2NGYiRSEeoSGyAvS9H+24JFA==",
+        "dependencies": {}
+      },
+      "@swc/core@1.3.93": {
+        "integrity": "sha512-690GRr1wUGmGYZHk7fUduX/JUwViMF2o74mnZYIWEcJaCcd9MQfkhsxPBtjeg6tF+h266/Cf3RPYhsFBzzxXcA==",
+        "dependencies": {
+          "@swc/core-darwin-arm64": "@swc/core-darwin-arm64@1.3.93",
+          "@swc/core-darwin-x64": "@swc/core-darwin-x64@1.3.93",
+          "@swc/core-linux-arm-gnueabihf": "@swc/core-linux-arm-gnueabihf@1.3.93",
+          "@swc/core-linux-arm64-gnu": "@swc/core-linux-arm64-gnu@1.3.93",
+          "@swc/core-linux-arm64-musl": "@swc/core-linux-arm64-musl@1.3.93",
+          "@swc/core-linux-x64-gnu": "@swc/core-linux-x64-gnu@1.3.93",
+          "@swc/core-linux-x64-musl": "@swc/core-linux-x64-musl@1.3.93",
+          "@swc/core-win32-arm64-msvc": "@swc/core-win32-arm64-msvc@1.3.93",
+          "@swc/core-win32-ia32-msvc": "@swc/core-win32-ia32-msvc@1.3.93",
+          "@swc/core-win32-x64-msvc": "@swc/core-win32-x64-msvc@1.3.93",
+          "@swc/counter": "@swc/counter@0.1.2",
+          "@swc/types": "@swc/types@0.1.5"
+        }
+      },
+      "@swc/counter@0.1.2": {
+        "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
+        "dependencies": {}
+      },
+      "@swc/types@0.1.5": {
+        "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
+        "dependencies": {}
+      },
       "@types/body-parser@1.19.3": {
         "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
         "dependencies": {
@@ -120,6 +352,10 @@
         "dependencies": {
           "@types/node": "@types/node@18.16.19"
         }
+      },
+      "@types/estree@1.0.3": {
+        "integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==",
+        "dependencies": {}
       },
       "@types/express-serve-static-core@4.17.37": {
         "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
@@ -185,6 +421,12 @@
           "negotiator": "negotiator@0.6.3"
         }
       },
+      "ansi-styles@3.2.1": {
+        "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+        "dependencies": {
+          "color-convert": "color-convert@1.9.3"
+        }
+      },
       "array-flatten@1.1.1": {
         "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
         "dependencies": {}
@@ -216,6 +458,24 @@
           "function-bind": "function-bind@1.1.1",
           "get-intrinsic": "get-intrinsic@1.2.1"
         }
+      },
+      "chalk@2.4.2": {
+        "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+        "dependencies": {
+          "ansi-styles": "ansi-styles@3.2.1",
+          "escape-string-regexp": "escape-string-regexp@1.0.5",
+          "supports-color": "supports-color@5.5.0"
+        }
+      },
+      "color-convert@1.9.3": {
+        "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+        "dependencies": {
+          "color-name": "color-name@1.1.3"
+        }
+      },
+      "color-name@1.1.3": {
+        "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+        "dependencies": {}
       },
       "content-disposition@0.5.4": {
         "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
@@ -259,6 +519,14 @@
       },
       "escape-html@1.0.3": {
         "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+        "dependencies": {}
+      },
+      "escape-string-regexp@1.0.5": {
+        "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+        "dependencies": {}
+      },
+      "estree-walker@2.0.2": {
+        "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
         "dependencies": {}
       },
       "etag@1.8.1": {
@@ -321,6 +589,10 @@
         "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
         "dependencies": {}
       },
+      "fsevents@2.3.3": {
+        "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+        "dependencies": {}
+      },
       "function-bind@1.1.1": {
         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
         "dependencies": {}
@@ -333,6 +605,16 @@
           "has-proto": "has-proto@1.0.1",
           "has-symbols": "has-symbols@1.0.3"
         }
+      },
+      "get-tsconfig@4.7.2": {
+        "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+        "dependencies": {
+          "resolve-pkg-maps": "resolve-pkg-maps@1.0.0"
+        }
+      },
+      "has-flag@3.0.0": {
+        "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+        "dependencies": {}
       },
       "has-proto@1.0.1": {
         "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
@@ -372,9 +654,19 @@
         "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
         "dependencies": {}
       },
+      "js-tokens@4.0.0": {
+        "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+        "dependencies": {}
+      },
       "lodash.merge@4.6.2": {
         "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
         "dependencies": {}
+      },
+      "magic-string@0.30.5": {
+        "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+        "dependencies": {
+          "@jridgewell/sourcemap-codec": "@jridgewell/sourcemap-codec@1.4.15"
+        }
       },
       "media-typer@0.3.0": {
         "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
@@ -432,6 +724,10 @@
         "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
         "dependencies": {}
       },
+      "picomatch@2.3.1": {
+        "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+        "dependencies": {}
+      },
       "proxy-addr@2.0.7": {
         "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
         "dependencies": {
@@ -456,6 +752,68 @@
           "http-errors": "http-errors@2.0.0",
           "iconv-lite": "iconv-lite@0.4.24",
           "unpipe": "unpipe@1.0.0"
+        }
+      },
+      "resolve-pkg-maps@1.0.0": {
+        "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+        "dependencies": {}
+      },
+      "rollup-plugin-alias@2.2.0": {
+        "integrity": "sha512-9ZK410qeFed4gGrHoojBpxLsHF74vPgsheGg9JRW5RbALAxqdvJbd357mSqWBqUrBfRVnZnNUXTZdYLxxQEA5A==",
+        "dependencies": {
+          "slash": "slash@3.0.0"
+        }
+      },
+      "rollup-plugin-dts@6.1.0_rollup@3.29.4_typescript@5.2.2": {
+        "integrity": "sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==",
+        "dependencies": {
+          "@babel/code-frame": "@babel/code-frame@7.22.13",
+          "magic-string": "magic-string@0.30.5",
+          "rollup": "rollup@3.29.4",
+          "typescript": "typescript@5.2.2"
+        }
+      },
+      "rollup-plugin-swc3@0.10.3_@swc+core@1.3.93_rollup@4.1.4": {
+        "integrity": "sha512-GWoMkm3ATumN8EPHBKLrpCufcRNn7SfLyvMKWUfCVLidPuPjlQZfNBeQXP6OEiHBguZzriCssX43EnV3+Y54bA==",
+        "dependencies": {
+          "@fastify/deepmerge": "@fastify/deepmerge@1.3.0",
+          "@rollup/pluginutils": "@rollup/pluginutils@5.0.5_rollup@4.1.4",
+          "@swc/core": "@swc/core@1.3.93",
+          "get-tsconfig": "get-tsconfig@4.7.2",
+          "rollup": "rollup@4.1.4",
+          "rollup-swc-preserve-directives": "rollup-swc-preserve-directives@0.5.0_@swc+core@1.3.93_rollup@3.29.4"
+        }
+      },
+      "rollup-swc-preserve-directives@0.5.0_@swc+core@1.3.93_rollup@3.29.4": {
+        "integrity": "sha512-6lnPZn2laSsdYcdCSE28z4Dwg2mCN5loF+/wBjybh25GJmONjHTf3orWa5j1zjEWY3RcGRjJ8K/52ePqtfy6dw==",
+        "dependencies": {
+          "@napi-rs/magic-string": "@napi-rs/magic-string@0.3.4",
+          "@swc/core": "@swc/core@1.3.93",
+          "rollup": "rollup@3.29.4"
+        }
+      },
+      "rollup@3.29.4": {
+        "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+        "dependencies": {
+          "fsevents": "fsevents@2.3.3"
+        }
+      },
+      "rollup@4.1.4": {
+        "integrity": "sha512-U8Yk1lQRKqCkDBip/pMYT+IKaN7b7UesK3fLSTuHBoBJacCE+oBqo/dfG/gkUdQNNB2OBmRP98cn2C2bkYZkyw==",
+        "dependencies": {
+          "@rollup/rollup-android-arm-eabi": "@rollup/rollup-android-arm-eabi@4.1.4",
+          "@rollup/rollup-android-arm64": "@rollup/rollup-android-arm64@4.1.4",
+          "@rollup/rollup-darwin-arm64": "@rollup/rollup-darwin-arm64@4.1.4",
+          "@rollup/rollup-darwin-x64": "@rollup/rollup-darwin-x64@4.1.4",
+          "@rollup/rollup-linux-arm-gnueabihf": "@rollup/rollup-linux-arm-gnueabihf@4.1.4",
+          "@rollup/rollup-linux-arm64-gnu": "@rollup/rollup-linux-arm64-gnu@4.1.4",
+          "@rollup/rollup-linux-arm64-musl": "@rollup/rollup-linux-arm64-musl@4.1.4",
+          "@rollup/rollup-linux-x64-gnu": "@rollup/rollup-linux-x64-gnu@4.1.4",
+          "@rollup/rollup-linux-x64-musl": "@rollup/rollup-linux-x64-musl@4.1.4",
+          "@rollup/rollup-win32-arm64-msvc": "@rollup/rollup-win32-arm64-msvc@4.1.4",
+          "@rollup/rollup-win32-ia32-msvc": "@rollup/rollup-win32-ia32-msvc@4.1.4",
+          "@rollup/rollup-win32-x64-msvc": "@rollup/rollup-win32-x64-msvc@4.1.4",
+          "fsevents": "fsevents@2.3.3"
         }
       },
       "safe-buffer@5.2.1": {
@@ -505,9 +863,23 @@
           "object-inspect": "object-inspect@1.12.3"
         }
       },
+      "slash@3.0.0": {
+        "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+        "dependencies": {}
+      },
+      "slash@4.0.0": {
+        "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+        "dependencies": {}
+      },
       "statuses@2.0.1": {
         "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
         "dependencies": {}
+      },
+      "supports-color@5.5.0": {
+        "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+        "dependencies": {
+          "has-flag": "has-flag@3.0.0"
+        }
       },
       "toidentifier@1.0.1": {
         "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
@@ -519,6 +891,10 @@
           "media-typer": "media-typer@0.3.0",
           "mime-types": "mime-types@2.1.35"
         }
+      },
+      "typescript@5.2.2": {
+        "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+        "dependencies": {}
       },
       "unpipe@1.0.0": {
         "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
@@ -533,6 +909,10 @@
         "dependencies": {}
       }
     }
+  },
+  "redirects": {
+    "https://esm.sh/rollup-plugin-swc": "https://esm.sh/rollup-plugin-swc@0.2.1",
+    "https://esm.sh/rollup-plugin-swc3": "https://esm.sh/rollup-plugin-swc3@0.10.3"
   },
   "remote": {
     "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",

--- a/examples/deno-fresh/deno.json
+++ b/examples/deno-fresh/deno.json
@@ -8,11 +8,16 @@
   "imports": {
     "$autometrics/": "../../packages/autometrics/",
     "$fresh/": "https://deno.land/x/fresh@1.5.2/",
+    "$otel/api": "npm:@opentelemetry/api@^1.6.0",
+    "$otel/core": "npm:@opentelemetry/core@^1.17.0",
+    "$otel/exporter-metrics-otlp-http": "npm:@opentelemetry/exporter-metrics-otlp-http@^0.43.0",
+    "$otel/resources": "npm:@opentelemetry/resources@^1.17.0",
+    "$otel/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.17.0",
+    "$std/": "https://deno.land/std@0.203.0/",
     "preact": "https://esm.sh/preact@10.18.1",
     "preact/": "https://esm.sh/preact@10.18.1/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.2",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.2.1",
-    "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.0",
-    "$std/": "https://deno.land/std@0.203.0/"
+    "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.0"
   }
 }

--- a/examples/deno-fresh/deno.json
+++ b/examples/deno-fresh/deno.json
@@ -8,11 +8,7 @@
   "imports": {
     "$autometrics/": "../../packages/autometrics/",
     "$fresh/": "https://deno.land/x/fresh@1.5.2/",
-    "$otel/api": "npm:@opentelemetry/api@^1.6.0",
-    "$otel/core": "npm:@opentelemetry/core@^1.17.0",
-    "$otel/exporter-metrics-otlp-http": "npm:@opentelemetry/exporter-metrics-otlp-http@^0.43.0",
-    "$otel/resources": "npm:@opentelemetry/resources@^1.17.0",
-    "$otel/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.17.0",
+    "$otel/": "npm:/@opentelemetry/",
     "$std/": "https://deno.land/std@0.203.0/",
     "preact": "https://esm.sh/preact@10.18.1",
     "preact/": "https://esm.sh/preact@10.18.1/",

--- a/examples/deno-fresh/deno.lock
+++ b/examples/deno-fresh/deno.lock
@@ -2,8 +2,11 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "npm:@opentelemetry/api": "npm:@opentelemetry/api@1.6.0",
       "npm:@opentelemetry/api@^1.6.0": "npm:@opentelemetry/api@1.6.0",
+      "npm:@opentelemetry/exporter-metrics-otlp-http": "npm:@opentelemetry/exporter-metrics-otlp-http@0.43.0_@opentelemetry+api@1.6.0",
       "npm:@opentelemetry/exporter-metrics-otlp-http@^0.43.0": "npm:@opentelemetry/exporter-metrics-otlp-http@0.43.0_@opentelemetry+api@1.6.0",
+      "npm:@opentelemetry/sdk-metrics": "npm:@opentelemetry/sdk-metrics@1.17.1_@opentelemetry+api@1.6.0",
       "npm:@opentelemetry/sdk-metrics@^1.17.0": "npm:@opentelemetry/sdk-metrics@1.17.1_@opentelemetry+api@1.6.0"
     },
     "npm": {

--- a/examples/deno-fresh/justfile
+++ b/examples/deno-fresh/justfile
@@ -12,3 +12,6 @@ test:
 
 type-check:
     deno check main.ts
+
+clean:
+    true # nothing to clean

--- a/examples/express/justfile
+++ b/examples/express/justfile
@@ -11,4 +11,4 @@ type-check:
     npx tsc -p tsconfig.json --noEmit
 
 clean:
-    rm -Rf dist
+    rm -Rf dist node_modules

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -15,7 +15,7 @@
     "@opentelemetry/exporter-prometheus": "^0.43.0",
     "@opentelemetry/sdk-metrics": "^1.17.0",
     "@types/express": "^4.17.16",
-    "@types/node": "^20.8.2",
+    "@types/node": "^18.6.5",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/examples/express/tests/callerInfo.test.ts
+++ b/examples/express/tests/callerInfo.test.ts
@@ -22,11 +22,11 @@ test("Caller info test", async (t) => {
 
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/dist\/tests\/callerInfo.test.js"\S*\} 1/gm,
       );
     },
   );
@@ -49,11 +49,11 @@ test("Caller info test", async (t) => {
 
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assert.match(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/dist\/tests\/callerInfo.test.js"\S*\} 1/gm,
       );
     },
   );

--- a/examples/express/tests/callerInfo.test.ts
+++ b/examples/express/tests/callerInfo.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert";
+import test from "node:test";
+
+import { autometrics } from "@autometrics/autometrics";
+
+import { collectAndSerialize, stepWithMetricReader } from "./test-utils.js";
+
+test("Caller info test", async (t) => {
+  await stepWithMetricReader(
+    t,
+    "caller is tracked in synchronous call",
+    async (metricReader) => {
+      const foo = autometrics(function foo() {});
+
+      const bar = autometrics(function bar() {
+        foo();
+      });
+
+      bar();
+
+      const serialized = await collectAndSerialize(metricReader);
+
+      assert.match(
+        serialized,
+        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      );
+      assert.match(
+        serialized,
+        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      );
+    },
+  );
+
+  await stepWithMetricReader(
+    t,
+    "caller is tracked in asynchronous call",
+    async (metricReader) => {
+      const foo = autometrics(function foo() {
+        return Promise.resolve();
+      });
+
+      const bar = autometrics(async function bar() {
+        await foo();
+      });
+
+      await bar();
+
+      const serialized = await collectAndSerialize(metricReader);
+
+      assert.match(
+        serialized,
+        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      );
+      assert.match(
+        serialized,
+        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      );
+    },
+  );
+});

--- a/examples/express/tests/test-utils.ts
+++ b/examples/express/tests/test-utils.ts
@@ -25,7 +25,7 @@ export async function stepWithMetricReader(
   registerExporter({ metricReader });
 
   try {
-    t.test(stepName, () => testFn(metricReader));
+    await t.test(stepName, () => testFn(metricReader));
   } finally {
     await metricReader.forceFlush();
   }

--- a/examples/faas-experimental/justfile
+++ b/examples/faas-experimental/justfile
@@ -11,4 +11,4 @@ type-check:
     npx tsc -p tsconfig.json --noEmit
 
 clean:
-    true # nothing to clean
+    rm -Rf node_modules

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -9,6 +9,10 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "workspaces": [
+    "../../dist/autometrics",
+    "../../dist/exporter-prometheus"
+  ],
   "dependencies": {
     "@autometrics/autometrics": "portal:../../dist/autometrics",
     "@autometrics/exporter-prometheus": "portal:../../dist/exporter-prometheus",

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@autometrics/typescript-plugin": "^0.5.4",
-    "@types/node": "^18.13.0",
+    "@types/node": "^18.6.5",
     "prisma": "^5.2.0",
     "typescript": "^5.2.2"
   }

--- a/examples/fastify/yarn.lock
+++ b/examples/fastify/yarn.lock
@@ -5,15 +5,15 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/autometrics@npm:beta":
-  version: 0.7.2-beta.0
-  resolution: "@autometrics/autometrics@npm:0.7.2-beta.0"
+"@autometrics/autometrics@0.8.0-dev, @autometrics/autometrics@workspace:../../dist/autometrics":
+  version: 0.0.0-use.local
+  resolution: "@autometrics/autometrics@workspace:../../dist/autometrics"
   dependencies:
-    "@opentelemetry/api": ^1.3.0
-    "@opentelemetry/sdk-metrics": ">=1.15.0"
-  checksum: bed24e00e0fa704ed3442f256db4da2645f183986919cd0bb7985c784d21aa18241f33d587ae921d2c3068f66cfb36e6f34eb74f26f7b4f099b99b6722bed34b
-  languageName: node
-  linkType: hard
+    "@opentelemetry/api": ^1.6.0
+    "@opentelemetry/sdk-metrics": ^1.17.0
+    "@types/node": ^18.6.5
+  languageName: unknown
+  linkType: soft
 
 "@autometrics/autometrics@portal:../../dist/autometrics::locator=fastify-example%40workspace%3A.":
   version: 0.0.0-use.local
@@ -28,11 +28,23 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autometrics/exporter-prometheus@portal:../../dist/exporter-prometheus::locator=fastify-example%40workspace%3A."
   dependencies:
-    "@autometrics/autometrics": beta
+    "@autometrics/autometrics": 0.8.0-dev
     "@opentelemetry/api": ^1.6.0
     "@opentelemetry/exporter-prometheus": ^0.43.0
     "@opentelemetry/sdk-metrics": ^1.17.0
   languageName: node
+  linkType: soft
+
+"@autometrics/exporter-prometheus@workspace:../../dist/exporter-prometheus":
+  version: 0.0.0-use.local
+  resolution: "@autometrics/exporter-prometheus@workspace:../../dist/exporter-prometheus"
+  dependencies:
+    "@autometrics/autometrics": 0.8.0-dev
+    "@opentelemetry/api": ^1.6.0
+    "@opentelemetry/exporter-prometheus": ^0.43.0
+    "@opentelemetry/sdk-metrics": ^1.17.0
+    "@types/node": ^18.6.5
+  languageName: unknown
   linkType: soft
 
 "@autometrics/typescript-plugin@npm:^0.5.4":
@@ -76,7 +88,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.6.0":
+"@opentelemetry/api@npm:^1.6.0":
   version: 1.6.0
   resolution: "@opentelemetry/api@npm:1.6.0"
   checksum: 3283b78b62a39f6568eaa050ac7045fcca747679e255874f6d2107cb8e1a3b2e10bfbf553c3e82a72500fb5fdca49dc07a5fe27fd6980debac24506cca638859
@@ -155,7 +167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-metrics@npm:>=1.15.0, @opentelemetry/sdk-metrics@npm:^1.17.0":
+"@opentelemetry/sdk-metrics@npm:^1.17.0":
   version: 1.17.1
   resolution: "@opentelemetry/sdk-metrics@npm:1.17.1"
   dependencies:

--- a/examples/fastify/yarn.lock
+++ b/examples/fastify/yarn.lock
@@ -210,7 +210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.13.0":
+"@types/node@npm:^18.6.5":
   version: 18.18.6
   resolution: "@types/node@npm:18.18.6"
   checksum: a847639b8455fd3dfa6dbc2917274c82c9db789f1d41aaf69f94ac6c9e54c3c1dd29be6e1e1ccd7c17e54db3d78d7011bc4e70544c6447ceca253dccc0a187e1
@@ -400,7 +400,7 @@ __metadata:
     "@autometrics/exporter-prometheus": "portal:../../dist/exporter-prometheus"
     "@autometrics/typescript-plugin": ^0.5.4
     "@prisma/client": ^5.2.0
-    "@types/node": ^18.13.0
+    "@types/node": ^18.6.5
     fastify: ^4.13.0
     prisma: ^5.2.0
     typescript: ^5.2.2

--- a/examples/hono-bun/justfile
+++ b/examples/hono-bun/justfile
@@ -11,4 +11,4 @@ type-check:
     bun x tsc -p tsconfig.json --noEmit
 
 clean:
-    true # nothing to clean
+    rm -Rf node_modules

--- a/examples/hono-bun/tests/callerInfo.test.ts
+++ b/examples/hono-bun/tests/callerInfo.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+
+import { autometrics } from "@autometrics/autometrics";
+
+import { collectAndSerialize, testWithMetricReader } from "./test-utils.js";
+
+test("Caller info test", async () => {
+  await testWithMetricReader(async (metricReader) => {
+    const foo = autometrics(function foo() {});
+
+    const bar = autometrics(function bar() {
+      foo();
+    });
+
+    bar();
+
+    const serialized = await collectAndSerialize(metricReader);
+
+    expect(serialized).toMatch(
+      /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+    );
+    expect(serialized).toMatch(
+      /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+    );
+  });
+});

--- a/examples/hono-bun/tests/callerInfo.test.ts
+++ b/examples/hono-bun/tests/callerInfo.test.ts
@@ -17,10 +17,10 @@ test("Caller info test -- synchronous call", async () => {
     const serialized = await collectAndSerialize(metricReader);
 
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
     );
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/tests\/callerInfo.test.ts"\S*\} 1/gm,
     );
   });
 });
@@ -40,10 +40,10 @@ test("Caller info test -- asynchronous call", async () => {
     const serialized = await collectAndSerialize(metricReader);
 
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
     );
     expect(serialized).toMatch(
-      /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/tests\/callerInfo.test.ts"\S*\} 1/gm,
     );
   });
 });

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -28,7 +28,7 @@
     "@nestjs/testing": "^9.0.0",
     "@types/express": "^4.17.13",
     "@types/jest": "29.2.4",
-    "@types/node": "18.11.18",
+    "@types/node": "^18.6.5",
     "@types/supertest": "^2.0.11",
     "source-map-support": "^0.5.20",
     "tsconfig-paths": "4.1.1",

--- a/examples/react-app-experimental/.yarnrc.yml
+++ b/examples/react-app-experimental/.yarnrc.yml
@@ -1,0 +1,3 @@
+nodeLinker: pnpm
+
+yarnPath: ../../.yarn/releases/yarn-3.6.4.cjs

--- a/examples/react-app-experimental/justfile
+++ b/examples/react-app-experimental/justfile
@@ -2,7 +2,7 @@ build:
     yarn && yarn build
 
 start:
-    yarn start
+    yarn preview
 
 test:
     true # no tests; no issues
@@ -11,4 +11,4 @@ type-check:
     yarn tsc -p tsconfig.json --noEmit
 
 clean:
-    rm -Rf build node_modules .yarn
+    rm -Rf dist node_modules .yarn

--- a/examples/react-app-experimental/package.json
+++ b/examples/react-app-experimental/package.json
@@ -5,12 +5,16 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
+  "workspaces": [
+    "../../dist/autometrics",
+    "../../dist/exporter-prometheus"
+  ],
   "dependencies": {
-    "@autometrics/autometrics": "beta",
-    "@autometrics/exporter-otlp-http": "beta",
+    "@autometrics/autometrics": "portal:../../dist/autometrics",
+    "@autometrics/exporter-otlp-http": "portal:../../dist/exporter-otlp-http",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -19,7 +23,7 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^3.1.0",
-    "typescript": "^4.9.3",
-    "vite": "^4.1.0"
+    "typescript": "^5.2.2",
+    "vite": "^4.5.0"
   }
 }

--- a/examples/react-app-experimental/src/App.tsx
+++ b/examples/react-app-experimental/src/App.tsx
@@ -15,7 +15,7 @@ import "./App.css";
 init({
   // A proxy configured in `vite.config.ts` forwards the `/metrics` endpoint
   // to the Otel Collector.
-  url: "/metrics",
+  url: `${location.origin}/metrics`,
   // Uncomment the next line to push "eagerly" instead of in batches. Eager
   // pushing may generate more traffic, but reduces chances of missing metrics
   // when the user closes their tab.

--- a/examples/react-app-experimental/yarn.lock
+++ b/examples/react-app-experimental/yarn.lock
@@ -5,9 +5,19 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@autometrics/autometrics@0.8.0-dev, @autometrics/autometrics@workspace:dist/autometrics":
+"@ampproject/remapping@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "@ampproject/remapping@npm:2.2.1"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 03c04fd526acc64a1f4df22651186f3e5ef0a9d6d6530ce4482ec9841269cf7a11dbb8af79237c282d721c5312024ff17529cd72cc4768c11e999b58e2302079
+  languageName: node
+  linkType: hard
+
+"@autometrics/autometrics@0.8.0-dev, @autometrics/autometrics@workspace:../../dist/autometrics":
   version: 0.0.0-use.local
-  resolution: "@autometrics/autometrics@workspace:dist/autometrics"
+  resolution: "@autometrics/autometrics@workspace:../../dist/autometrics"
   dependencies:
     "@opentelemetry/api": ^1.6.0
     "@opentelemetry/sdk-metrics": ^1.17.0
@@ -15,34 +25,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autometrics/exporter-otlp-http@workspace:dist/exporter-otlp-http":
+"@autometrics/autometrics@portal:../../dist/autometrics::locator=react-app-example%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "@autometrics/exporter-otlp-http@workspace:dist/exporter-otlp-http"
+  resolution: "@autometrics/autometrics@portal:../../dist/autometrics::locator=react-app-example%40workspace%3A."
+  dependencies:
+    "@opentelemetry/api": ^1.6.0
+    "@opentelemetry/sdk-metrics": ^1.17.0
+  languageName: node
+  linkType: soft
+
+"@autometrics/exporter-otlp-http@portal:../../dist/exporter-otlp-http::locator=react-app-example%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@autometrics/exporter-otlp-http@portal:../../dist/exporter-otlp-http::locator=react-app-example%40workspace%3A."
   dependencies:
     "@autometrics/autometrics": 0.8.0-dev
     "@opentelemetry/api": ^1.6.0
     "@opentelemetry/exporter-metrics-otlp-http": ^0.43.0
     "@opentelemetry/sdk-metrics": ^1.17.0
-    "@types/node": ^18.6.5
-  languageName: unknown
+  languageName: node
   linkType: soft
 
-"@autometrics/exporter-prometheus-push-gateway@workspace:dist/exporter-prometheus-push-gateway":
+"@autometrics/exporter-prometheus@workspace:../../dist/exporter-prometheus":
   version: 0.0.0-use.local
-  resolution: "@autometrics/exporter-prometheus-push-gateway@workspace:dist/exporter-prometheus-push-gateway"
-  dependencies:
-    "@autometrics/autometrics": 0.8.0-dev
-    "@opentelemetry/api": ^1.6.0
-    "@opentelemetry/core": ^1.17.0
-    "@opentelemetry/exporter-prometheus": ^0.43.0
-    "@opentelemetry/sdk-metrics": ^1.17.0
-    "@types/node": ^18.6.5
-  languageName: unknown
-  linkType: soft
-
-"@autometrics/exporter-prometheus@workspace:dist/exporter-prometheus":
-  version: 0.0.0-use.local
-  resolution: "@autometrics/exporter-prometheus@workspace:dist/exporter-prometheus"
+  resolution: "@autometrics/exporter-prometheus@workspace:../../dist/exporter-prometheus"
   dependencies:
     "@autometrics/autometrics": 0.8.0-dev
     "@opentelemetry/api": ^1.6.0
@@ -52,24 +57,420 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autometrics/parcel-transformer-autometrics@workspace:packages/parcel-transformer-autometrics":
-  version: 0.0.0-use.local
-  resolution: "@autometrics/parcel-transformer-autometrics@workspace:packages/parcel-transformer-autometrics"
-  dependencies:
-    "@parcel/core": ^2.10.0
-    "@parcel/plugin": ^2.9.0
-    "@types/node": ^18.6.5
-    typescript: ">=5.0.4"
-  languageName: unknown
-  linkType: soft
+"@autometrics/typescript-plugin@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@autometrics/typescript-plugin@npm:0.5.4"
+  checksum: df18888dcb824ac9ac0e0b00532a4026e49deb118b5ad0a44d9f063a71ac4b9c2fdcc82a831d981ca7d805a23c071616d0f20403ead801dadb8c9dfa74af108b
+  languageName: node
+  linkType: hard
 
-"@autometrics/typescript-plugin@workspace:packages/typescript-plugin":
-  version: 0.0.0-use.local
-  resolution: "@autometrics/typescript-plugin@workspace:packages/typescript-plugin"
+"@babel/code-frame@npm:^7.22.13":
+  version: 7.22.13
+  resolution: "@babel/code-frame@npm:7.22.13"
   dependencies:
-    typescript: ^5.0.4
-  languageName: unknown
-  linkType: soft
+    "@babel/highlight": ^7.22.13
+    chalk: ^2.4.2
+  checksum: 22e342c8077c8b77eeb11f554ecca2ba14153f707b85294fcf6070b6f6150aae88a7b7436dd88d8c9289970585f3fe5b9b941c5aa3aa26a6d5a8ef3f292da058
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.22.9":
+  version: 7.23.2
+  resolution: "@babel/compat-data@npm:7.23.2"
+  checksum: d8dc27437d40907b271161d4c88ffe72ccecb034c730deb1960a417b59a14d7c5ebca8cd80dd458a01cd396a7a329eb48cddcc3791b5a84da33d7f278f7bec6a
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.20.12":
+  version: 7.23.2
+  resolution: "@babel/core@npm:7.23.2"
+  dependencies:
+    "@ampproject/remapping": ^2.2.0
+    "@babel/code-frame": ^7.22.13
+    "@babel/generator": ^7.23.0
+    "@babel/helper-compilation-targets": ^7.22.15
+    "@babel/helper-module-transforms": ^7.23.0
+    "@babel/helpers": ^7.23.2
+    "@babel/parser": ^7.23.0
+    "@babel/template": ^7.22.15
+    "@babel/traverse": ^7.23.2
+    "@babel/types": ^7.23.0
+    convert-source-map: ^2.0.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.3
+    semver: ^6.3.1
+  checksum: 003897718ded16f3b75632d63cd49486bf67ff206cc7ebd1a10d49e2456f8d45740910d5ec7e42e3faf0deec7a2e96b1a02e766d19a67a8309053f0d4e57c0fe
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/generator@npm:7.23.0"
+  dependencies:
+    "@babel/types": ^7.23.0
+    "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
+    jsesc: ^2.5.1
+  checksum: 8efe24adad34300f1f8ea2add420b28171a646edc70f2a1b3e1683842f23b8b7ffa7e35ef0119294e1901f45bfea5b3dc70abe1f10a1917ccdfb41bed69be5f1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-compilation-targets@npm:7.22.15"
+  dependencies:
+    "@babel/compat-data": ^7.22.9
+    "@babel/helper-validator-option": ^7.22.15
+    browserslist: ^4.21.9
+    lru-cache: ^5.1.1
+    semver: ^6.3.1
+  checksum: ce85196769e091ae54dd39e4a80c2a9df1793da8588e335c383d536d54f06baf648d0a08fc873044f226398c4ded15c4ae9120ee18e7dfd7c639a68e3cdc9980
+  languageName: node
+  linkType: hard
+
+"@babel/helper-environment-visitor@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-environment-visitor@npm:7.22.20"
+  checksum: d80ee98ff66f41e233f36ca1921774c37e88a803b2f7dca3db7c057a5fea0473804db9fb6729e5dbfd07f4bed722d60f7852035c2c739382e84c335661590b69
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/helper-function-name@npm:7.23.0"
+  dependencies:
+    "@babel/template": ^7.22.15
+    "@babel/types": ^7.23.0
+  checksum: e44542257b2d4634a1f979244eb2a4ad8e6d75eb6761b4cfceb56b562f7db150d134bc538c8e6adca3783e3bc31be949071527aa8e3aab7867d1ad2d84a26e10
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-hoist-variables@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 394ca191b4ac908a76e7c50ab52102669efe3a1c277033e49467913c7ed6f7c64d7eacbeabf3bed39ea1f41731e22993f763b1edce0f74ff8563fd1f380d92cc
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-module-imports@npm:7.22.15"
+  dependencies:
+    "@babel/types": ^7.22.15
+  checksum: ecd7e457df0a46f889228f943ef9b4a47d485d82e030676767e6a2fdcbdaa63594d8124d4b55fd160b41c201025aec01fc27580352b1c87a37c9c6f33d116702
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/helper-module-transforms@npm:7.23.0"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.22.20
+    "@babel/helper-module-imports": ^7.22.15
+    "@babel/helper-simple-access": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.6
+    "@babel/helper-validator-identifier": ^7.22.20
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 6e2afffb058cf3f8ce92f5116f710dda4341c81cfcd872f9a0197ea594f7ce0ab3cb940b0590af2fe99e60d2e5448bfba6bca8156ed70a2ed4be2adc8586c891
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-plugin-utils@npm:7.22.5"
+  checksum: c0fc7227076b6041acd2f0e818145d2e8c41968cc52fb5ca70eed48e21b8fe6dd88a0a91cbddf4951e33647336eb5ae184747ca706817ca3bef5e9e905151ff5
+  languageName: node
+  linkType: hard
+
+"@babel/helper-simple-access@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-simple-access@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: fe9686714caf7d70aedb46c3cce090f8b915b206e09225f1e4dbc416786c2fdbbee40b38b23c268b7ccef749dd2db35f255338fb4f2444429874d900dede5ad2
+  languageName: node
+  linkType: hard
+
+"@babel/helper-split-export-declaration@npm:^7.22.6":
+  version: 7.22.6
+  resolution: "@babel/helper-split-export-declaration@npm:7.22.6"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: e141cace583b19d9195f9c2b8e17a3ae913b7ee9b8120246d0f9ca349ca6f03cb2c001fd5ec57488c544347c0bb584afec66c936511e447fd20a360e591ac921
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-string-parser@npm:7.22.5"
+  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
+  checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-validator-option@npm:7.22.15"
+  checksum: 68da52b1e10002a543161494c4bc0f4d0398c8fdf361d5f7f4272e95c45d5b32d974896d44f6a0ea7378c9204988879d73613ca683e13bd1304e46d25ff67a8d
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.23.2":
+  version: 7.23.2
+  resolution: "@babel/helpers@npm:7.23.2"
+  dependencies:
+    "@babel/template": ^7.22.15
+    "@babel/traverse": ^7.23.2
+    "@babel/types": ^7.23.0
+  checksum: aaf4828df75ec460eaa70e5c9f66e6dadc28dae3728ddb7f6c13187dbf38030e142194b83d81aa8a31bbc35a5529a5d7d3f3cf59d5d0b595f5dd7f9d8f1ced8e
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.22.13":
+  version: 7.22.20
+  resolution: "@babel/highlight@npm:7.22.20"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.22.20
+    chalk: ^2.4.2
+    js-tokens: ^4.0.0
+  checksum: 84bd034dca309a5e680083cd827a766780ca63cef37308404f17653d32366ea76262bd2364b2d38776232f2d01b649f26721417d507e8b4b6da3e4e739f6d134
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/parser@npm:7.23.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 453fdf8b9e2c2b7d7b02139e0ce003d1af21947bbc03eb350fb248ee335c9b85e4ab41697ddbdd97079698de825a265e45a0846bb2ed47a2c7c1df833f42a354
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-self@npm:^7.18.6":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.22.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 671eebfabd14a0c7d6ae805fff7e289dfdb7ba984bb100ea2ef6dad1d6a665ebbb09199ab2e64fca7bc78bd0fdc80ca897b07996cf215fafc32c67bc564309af
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-source@npm:^7.19.6":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.22.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4ca2bd62ca14f8bbdcda9139f3f799e1c1c1bae504b67c1ca9bca142c53d81926d1a2b811f66a625f20999b2d352131053d886601f1ba3c1e9378c104d884277
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/template@npm:7.22.15"
+  dependencies:
+    "@babel/code-frame": ^7.22.13
+    "@babel/parser": ^7.22.15
+    "@babel/types": ^7.22.15
+  checksum: 1f3e7dcd6c44f5904c184b3f7fe280394b191f2fed819919ffa1e529c259d5b197da8981b6ca491c235aee8dbad4a50b7e31304aa531271cb823a4a24a0dd8fd
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.23.2":
+  version: 7.23.2
+  resolution: "@babel/traverse@npm:7.23.2"
+  dependencies:
+    "@babel/code-frame": ^7.22.13
+    "@babel/generator": ^7.23.0
+    "@babel/helper-environment-visitor": ^7.22.20
+    "@babel/helper-function-name": ^7.23.0
+    "@babel/helper-hoist-variables": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.6
+    "@babel/parser": ^7.23.0
+    "@babel/types": ^7.23.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 26a1eea0dde41ab99dde8b9773a013a0dc50324e5110a049f5d634e721ff08afffd54940b3974a20308d7952085ac769689369e9127dea655f868c0f6e1ab35d
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.8.3":
+  version: 7.23.0
+  resolution: "@babel/types@npm:7.23.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.20
+    to-fast-properties: ^2.0.0
+  checksum: 215fe04bd7feef79eeb4d33374b39909ce9cad1611c4135a4f7fdf41fe3280594105af6d7094354751514625ea92d0875aba355f53e86a92600f290e77b0e604
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/android-arm64@npm:0.18.20"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/android-arm@npm:0.18.20"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/android-x64@npm:0.18.20"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/darwin-arm64@npm:0.18.20"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/darwin-x64@npm:0.18.20"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/freebsd-arm64@npm:0.18.20"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/freebsd-x64@npm:0.18.20"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-arm64@npm:0.18.20"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-arm@npm:0.18.20"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-ia32@npm:0.18.20"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-loong64@npm:0.18.20"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-mips64el@npm:0.18.20"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-ppc64@npm:0.18.20"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-riscv64@npm:0.18.20"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-s390x@npm:0.18.20"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-x64@npm:0.18.20"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/netbsd-x64@npm:0.18.20"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/openbsd-x64@npm:0.18.20"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/sunos-x64@npm:0.18.20"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/win32-arm64@npm:0.18.20"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/win32-ia32@npm:0.18.20"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/win32-x64@npm:0.18.20"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
 
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
@@ -85,114 +486,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@lezer/common@npm:1.1.0"
-  checksum: 93c208a44d1c0bdf7407853ba7c4ddcedf1c52d1b82170813d83b9bd6301aa23587405ac54332fe39ce8bc37f706936ab237ceb4d3d535d1dead650153b6474c
-  languageName: node
-  linkType: hard
-
-"@lezer/lr@npm:^1.0.0":
-  version: 1.3.13
-  resolution: "@lezer/lr@npm:1.3.13"
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
+  version: 0.3.3
+  resolution: "@jridgewell/gen-mapping@npm:0.3.3"
   dependencies:
-    "@lezer/common": ^1.0.0
-  checksum: aad0cb8908796a6b49116842fd490093aa0de54b48150a60a4f418815c014f7a1b4355615832e305caea5c0ba8c5ab577f82aebcd0ea04586b8199284ef0fec8
+    "@jridgewell/set-array": ^1.0.1
+    "@jridgewell/sourcemap-codec": ^1.4.10
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 4a74944bd31f22354fc01c3da32e83c19e519e3bbadafa114f6da4522ea77dd0c2842607e923a591d60a76699d819a2fbb6f3552e277efdb9b58b081390b60ab
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-darwin-arm64@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@lmdb/lmdb-darwin-arm64@npm:2.8.5"
-  conditions: os=darwin & cpu=arm64
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "@jridgewell/resolve-uri@npm:3.1.1"
+  checksum: f5b441fe7900eab4f9155b3b93f9800a916257f4e8563afbcd3b5a5337b55e52bd8ae6735453b1b745457d9f6cdb16d74cd6220bbdd98cf153239e13f6cbb653
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-darwin-x64@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@lmdb/lmdb-darwin-x64@npm:2.8.5"
-  conditions: os=darwin & cpu=x64
+"@jridgewell/set-array@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "@jridgewell/set-array@npm:1.1.2"
+  checksum: 69a84d5980385f396ff60a175f7177af0b8da4ddb81824cb7016a9ef914eee9806c72b6b65942003c63f7983d4f39a5c6c27185bbca88eb4690b62075602e28e
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-linux-arm64@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@lmdb/lmdb-linux-arm64@npm:2.8.5"
-  conditions: os=linux & cpu=arm64
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.13, @jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-linux-arm@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@lmdb/lmdb-linux-arm@npm:2.8.5"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@lmdb/lmdb-linux-x64@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@lmdb/lmdb-linux-x64@npm:2.8.5"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@lmdb/lmdb-win32-x64@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@lmdb/lmdb-win32-x64@npm:2.8.5"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@mischnic/json-sourcemap@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "@mischnic/json-sourcemap@npm:0.1.1"
+"@jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.20
+  resolution: "@jridgewell/trace-mapping@npm:0.3.20"
   dependencies:
-    "@lezer/common": ^1.0.0
-    "@lezer/lr": ^1.0.0
-    json5: ^2.2.1
-  checksum: 631d1080ec4b525b7b757e9e248d0974178961f366123e765c35ddbfe24e0d51562bec48e416aef4a5f78a6769058c24ea88a2109378a8562bff4fb94471bdfa
-  languageName: node
-  linkType: hard
-
-"@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.2"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@msgpackr-extract/msgpackr-extract-darwin-x64@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@msgpackr-extract/msgpackr-extract-darwin-x64@npm:3.0.2"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@msgpackr-extract/msgpackr-extract-linux-arm64@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@msgpackr-extract/msgpackr-extract-linux-arm64@npm:3.0.2"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@msgpackr-extract/msgpackr-extract-linux-arm@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@msgpackr-extract/msgpackr-extract-linux-arm@npm:3.0.2"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@msgpackr-extract/msgpackr-extract-linux-x64@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@msgpackr-extract/msgpackr-extract-linux-x64@npm:3.0.2"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.2"
-  conditions: os=win32 & cpu=x64
+    "@jridgewell/resolve-uri": ^3.1.0
+    "@jridgewell/sourcemap-codec": ^1.4.14
+  checksum: cd1a7353135f385909468ff0cf20bdd37e59f2ee49a13a966dedf921943e222082c583ade2b579ff6cd0d8faafcb5461f253e1bf2a9f48fec439211fdbe788f5
   languageName: node
   linkType: hard
 
@@ -232,7 +564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.17.1, @opentelemetry/core@npm:^1.17.0":
+"@opentelemetry/core@npm:1.17.1":
   version: 1.17.1
   resolution: "@opentelemetry/core@npm:1.17.1"
   dependencies:
@@ -335,7 +667,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-metrics@npm:1.17.1":
+"@opentelemetry/sdk-metrics@npm:1.17.0":
+  version: 1.17.0
+  resolution: "@opentelemetry/sdk-metrics@npm:1.17.0"
+  dependencies:
+    "@opentelemetry/core": 1.17.0
+    "@opentelemetry/resources": 1.17.0
+    lodash.merge: ^4.6.2
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.7.0"
+  checksum: 4f42e7be9c9425f1f2442d1ab333287d42f196b1295ac996aa28e2b414a4a1a034a8857f08ce23a6f32567735682421620f6b63de7c4592d0dc1dd4f487ce8ef
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:^1.17.0":
   version: 1.17.1
   resolution: "@opentelemetry/sdk-metrics@npm:1.17.1"
   dependencies:
@@ -375,372 +720,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/cache@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/cache@npm:2.10.0"
-  dependencies:
-    "@parcel/fs": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/utils": 2.10.0
-    lmdb: 2.8.5
-  peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: 209d474abd5175309aaae06f4cbaebc7d1aadee260702e26268b7889d74132430c8ea52b1cd1829a98b60474856f671d26b99e698bd8a66a08d2c58d3e1ba264
-  languageName: node
-  linkType: hard
-
-"@parcel/codeframe@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/codeframe@npm:2.10.0"
-  dependencies:
-    chalk: ^4.1.0
-  checksum: d87b17d3ce1c88652b3d66ee873e0578aadf90e718bcafaf16c7b39e0272cf61851530d9a3cda7482702afb9058a54f497b9e3cc706f2c36904ca0a6182ae2a1
-  languageName: node
-  linkType: hard
-
-"@parcel/core@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/core@npm:2.10.0"
-  dependencies:
-    "@mischnic/json-sourcemap": ^0.1.0
-    "@parcel/cache": 2.10.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/events": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/graph": 3.0.0
-    "@parcel/logger": 2.10.0
-    "@parcel/package-manager": 2.10.0
-    "@parcel/plugin": 2.10.0
-    "@parcel/profiler": 2.10.0
-    "@parcel/rust": 2.10.0
-    "@parcel/source-map": ^2.1.1
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
-    "@parcel/workers": 2.10.0
-    abortcontroller-polyfill: ^1.1.9
-    base-x: ^3.0.8
-    browserslist: ^4.6.6
-    clone: ^2.1.1
-    dotenv: ^7.0.0
-    dotenv-expand: ^5.1.0
-    json5: ^2.2.0
-    msgpackr: ^1.5.4
-    nullthrows: ^1.1.1
-    semver: ^7.5.2
-  checksum: c59c2971ea6edc379fc166fefe60a6cbbbea0ee1c84120b7396c5b1a6bcfac2e0409647a007b38d6da27285b43d6582144f136a4b8f1652d01df589f16ffa6f0
-  languageName: node
-  linkType: hard
-
-"@parcel/diagnostic@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/diagnostic@npm:2.10.0"
-  dependencies:
-    "@mischnic/json-sourcemap": ^0.1.0
-    nullthrows: ^1.1.1
-  checksum: 45c606ca52316433524060b4297b0d34a1b971a94bbd5e9e282aeaac3abb3d9f0839a97a7027fa653e7b3b77269962a0db5a960ffe345fac41c6235a14e15aa1
-  languageName: node
-  linkType: hard
-
-"@parcel/events@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/events@npm:2.10.0"
-  checksum: 1d21cd41862de2f21f2ab754b1d949fe17b062fbb8009a23d4d42f6836df7e1d37c2c8ca71304dce18d1168dedf0fcaa88c7c3eacc20611215b00700df0c9c73
-  languageName: node
-  linkType: hard
-
-"@parcel/fs@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/fs@npm:2.10.0"
-  dependencies:
-    "@parcel/rust": 2.10.0
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
-    "@parcel/watcher": ^2.0.7
-    "@parcel/workers": 2.10.0
-  peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: 10faae481cf4cd0d0ae270c60e070a925f510ca7c93d208bd3c4159da4aff5e4e2e0ea61b58f3638557a469aa706037b3065b526ef207bbb4fdbe6048d04c082
-  languageName: node
-  linkType: hard
-
-"@parcel/graph@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@parcel/graph@npm:3.0.0"
-  dependencies:
-    nullthrows: ^1.1.1
-  checksum: 0a9d5017f6179d3a35a9f97060d24486efe045277e831550e2885b8afc05288a2a898da3ec1f920cb89c02cce8941642b4522e67194a773d50062dadb36f4567
-  languageName: node
-  linkType: hard
-
-"@parcel/logger@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/logger@npm:2.10.0"
-  dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/events": 2.10.0
-  checksum: 52d0b5331dd72778da4a2be798bb2b6d5e72ecb317cdad3a4c546807be1e30aa59b1cca6c57314438b30e62d89b578354098b939d72618ab0634c33d0261ee91
-  languageName: node
-  linkType: hard
-
-"@parcel/markdown-ansi@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/markdown-ansi@npm:2.10.0"
-  dependencies:
-    chalk: ^4.1.0
-  checksum: 35e2d07ec81e271144fc0f7b5f00913dce787e8a6f4a308eb59269fbc50d751cae939fedfd03e30b4aeef0c7f1210af2d1990a5551f1d39eeb80c977feb72b04
-  languageName: node
-  linkType: hard
-
-"@parcel/node-resolver-core@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@parcel/node-resolver-core@npm:3.1.0"
-  dependencies:
-    "@mischnic/json-sourcemap": ^0.1.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/rust": 2.10.0
-    "@parcel/utils": 2.10.0
-    nullthrows: ^1.1.1
-    semver: ^7.5.2
-  checksum: dcdd39bc6a044200fa734fbc58bba9b59c5ee2978c460b2734378adc7d47d724bdd98e942b0822305d0cfbd93bed1bb4ea37a6b8f8f7198e002890d9095f28ed
-  languageName: node
-  linkType: hard
-
-"@parcel/package-manager@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/package-manager@npm:2.10.0"
-  dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/node-resolver-core": 3.1.0
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
-    "@parcel/workers": 2.10.0
-    semver: ^7.5.2
-  peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: 7c4a95d9df4a819f2613839d30165e653182017a6d7c1b155ee46c46a921d086672daa70effba70cbc78379bb634176da254162b868b89c0e1b117079cc8c914
-  languageName: node
-  linkType: hard
-
-"@parcel/plugin@npm:2.10.0, @parcel/plugin@npm:^2.9.0":
-  version: 2.10.0
-  resolution: "@parcel/plugin@npm:2.10.0"
-  dependencies:
-    "@parcel/types": 2.10.0
-  checksum: e13ba6e7e521078e7755ecdf906c0f1d8fe63efaec26bb66e2f0df22417e755bbced6dbbdea50698ad27944ed1a16944c143eb08c79e4118ea62bc7c60f62b5f
-  languageName: node
-  linkType: hard
-
-"@parcel/profiler@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/profiler@npm:2.10.0"
-  dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/events": 2.10.0
-    chrome-trace-event: ^1.0.2
-  checksum: 78d545edb76d72f962769df8964a3a19fe3d0b2b8c47a929eeafd9d71b3f00f2733428a649804057fce153a7fb71fa8bfdd25cc3102b32ea542b69af35f7ce4a
-  languageName: node
-  linkType: hard
-
-"@parcel/rust@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/rust@npm:2.10.0"
-  checksum: 466a78d27db445780593a6a5a1ce39406daabf3661b81aa8a714ba647d0e3b08532a23b86508a7e8b9cb95f8aa4f755c6e33148ba961f173283b96b72cc51ee6
-  languageName: node
-  linkType: hard
-
-"@parcel/source-map@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@parcel/source-map@npm:2.1.1"
-  dependencies:
-    detect-libc: ^1.0.3
-  checksum: 1fa27a7047ec08faf7fe1dd0e2ae95a27b84697ecfaed029d0b7d06e46d84ed8f98a9dc9d308fe623655f3c985052dcf7622de479bfa6103c44884fb7f6c810a
-  languageName: node
-  linkType: hard
-
-"@parcel/types@npm:2.10.0, @parcel/types@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/types@npm:2.10.0"
-  dependencies:
-    "@parcel/cache": 2.10.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/package-manager": 2.10.0
-    "@parcel/source-map": ^2.1.1
-    "@parcel/workers": 2.10.0
-    utility-types: ^3.10.0
-  checksum: 387aa079020ffec27f92d9496e0abd5e71e4b8e0ca1c9cf5b692737dd172d037302dd2c9d3cc32143813707050eb9de23e4e4eca32a65c402f6564a08da61e6f
-  languageName: node
-  linkType: hard
-
-"@parcel/utils@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/utils@npm:2.10.0"
-  dependencies:
-    "@parcel/codeframe": 2.10.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/markdown-ansi": 2.10.0
-    "@parcel/rust": 2.10.0
-    "@parcel/source-map": ^2.1.1
-    chalk: ^4.1.0
-    nullthrows: ^1.1.1
-  checksum: 9f4953ff9af730b59abbaa6f5f0c452a26848fc52d6f04a0facdc9ebfabb4434fd548ae38a7f882a4a5cd2db5a0b389b540fe7d2ffc6c286323062a764d2cc43
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-android-arm64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-android-arm64@npm:2.3.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-darwin-arm64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-darwin-arm64@npm:2.3.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-darwin-x64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-darwin-x64@npm:2.3.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-freebsd-x64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-freebsd-x64@npm:2.3.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-linux-arm-glibc@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-linux-arm-glibc@npm:2.3.0"
-  conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-linux-arm64-glibc@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-linux-arm64-glibc@npm:2.3.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-linux-arm64-musl@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-linux-arm64-musl@npm:2.3.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-linux-x64-glibc@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-linux-x64-glibc@npm:2.3.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-linux-x64-musl@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-linux-x64-musl@npm:2.3.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-win32-arm64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-win32-arm64@npm:2.3.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-win32-ia32@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-win32-ia32@npm:2.3.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher-win32-x64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@parcel/watcher-win32-x64@npm:2.3.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher@npm:^2.0.7":
-  version: 2.3.0
-  resolution: "@parcel/watcher@npm:2.3.0"
-  dependencies:
-    "@parcel/watcher-android-arm64": 2.3.0
-    "@parcel/watcher-darwin-arm64": 2.3.0
-    "@parcel/watcher-darwin-x64": 2.3.0
-    "@parcel/watcher-freebsd-x64": 2.3.0
-    "@parcel/watcher-linux-arm-glibc": 2.3.0
-    "@parcel/watcher-linux-arm64-glibc": 2.3.0
-    "@parcel/watcher-linux-arm64-musl": 2.3.0
-    "@parcel/watcher-linux-x64-glibc": 2.3.0
-    "@parcel/watcher-linux-x64-musl": 2.3.0
-    "@parcel/watcher-win32-arm64": 2.3.0
-    "@parcel/watcher-win32-ia32": 2.3.0
-    "@parcel/watcher-win32-x64": 2.3.0
-    detect-libc: ^1.0.3
-    is-glob: ^4.0.3
-    micromatch: ^4.0.5
-    node-addon-api: ^7.0.0
-    node-gyp: latest
-  dependenciesMeta:
-    "@parcel/watcher-android-arm64":
-      optional: true
-    "@parcel/watcher-darwin-arm64":
-      optional: true
-    "@parcel/watcher-darwin-x64":
-      optional: true
-    "@parcel/watcher-freebsd-x64":
-      optional: true
-    "@parcel/watcher-linux-arm-glibc":
-      optional: true
-    "@parcel/watcher-linux-arm64-glibc":
-      optional: true
-    "@parcel/watcher-linux-arm64-musl":
-      optional: true
-    "@parcel/watcher-linux-x64-glibc":
-      optional: true
-    "@parcel/watcher-linux-x64-musl":
-      optional: true
-    "@parcel/watcher-win32-arm64":
-      optional: true
-    "@parcel/watcher-win32-ia32":
-      optional: true
-    "@parcel/watcher-win32-x64":
-      optional: true
-  checksum: 12f494998dbae363cc9c48b49f7e09589c179e84133e3b6cd0c087573a7dc70b3adec458f95b39e3b8e4d9c93cff770ce15b1d2452d6741a5047f1ca90485ded
-  languageName: node
-  linkType: hard
-
-"@parcel/workers@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/workers@npm:2.10.0"
-  dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/profiler": 2.10.0
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
-    nullthrows: ^1.1.1
-  peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: e8b1701b53b2f3e913eee98e1e16def38a67d08b4835d25e1dd610505edc2f38c23729ec9b264ccd3c6ea3221814a314b657a3a3c41feebbdb01dcc34e69741c
-  languageName: node
-  linkType: hard
-
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -756,9 +735,58 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^18.6.5":
-  version: 18.18.5
-  resolution: "@types/node@npm:18.18.5"
-  checksum: fc8c9b2bf226270cf9085a7dac76ce09dd7c3519ec9b687ee2b50385954ab3709c45ca82d002d1536e24286803cd194d7ab7008acebdcd6681b8b19d4277fa5c
+  version: 18.18.6
+  resolution: "@types/node@npm:18.18.6"
+  checksum: a847639b8455fd3dfa6dbc2917274c82c9db789f1d41aaf69f94ac6c9e54c3c1dd29be6e1e1ccd7c17e54db3d78d7011bc4e70544c6447ceca253dccc0a187e1
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:*":
+  version: 15.7.9
+  resolution: "@types/prop-types@npm:15.7.9"
+  checksum: c7591d3ff7593e243908a07e1d3e2bb6e8879008af5800d8378115a90d0fdf669a1cae72a6d7f69e59c4fa7bb4c8ed61f6ebc1c520fe110c6f2b03ac02414072
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18.0.10":
+  version: 18.2.14
+  resolution: "@types/react-dom@npm:18.2.14"
+  dependencies:
+    "@types/react": "*"
+  checksum: 890289c70d1966c168037637c09cacefe6205bdd27a33252144a6b432595a2943775ac1a1accac0beddaeb67f8fdf721e076acb1adc990b08e51c3d9fd4e780c
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*, @types/react@npm:^18.0.27":
+  version: 18.2.31
+  resolution: "@types/react@npm:18.2.31"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: b11be8e39174d3303e308461400889e353e422d22b01d09795b2c35b7b99d5351716503d9ec5c58e4c2c871249603fa52840d45a34fb5901dd7a26e06129c716
+  languageName: node
+  linkType: hard
+
+"@types/scheduler@npm:*":
+  version: 0.16.5
+  resolution: "@types/scheduler@npm:0.16.5"
+  checksum: 5aae67331bb7877edc65f77f205fb03c3808d9e51c186afe26945ce69f4072886629580a751e9ce8573e4a7538d0dfa1e4ce388c7c451fa689a4c592fdf1ea45
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-react@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@vitejs/plugin-react@npm:3.1.0"
+  dependencies:
+    "@babel/core": ^7.20.12
+    "@babel/plugin-transform-react-jsx-self": ^7.18.6
+    "@babel/plugin-transform-react-jsx-source": ^7.19.6
+    magic-string: ^0.27.0
+    react-refresh: ^0.14.0
+  peerDependencies:
+    vite: ^4.1.0-beta.0
+  checksum: 450fac79e67cba9e1581c860f78e687b44108ab4117663ef20db279316e03cd8e87f94fef376e27cc5e200bd52813dcc09b70ea570c7c7cc291fcd47eb260fbc
   languageName: node
   linkType: hard
 
@@ -766,13 +794,6 @@ __metadata:
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
-  languageName: node
-  linkType: hard
-
-"abortcontroller-polyfill@npm:^1.1.9":
-  version: 1.7.5
-  resolution: "abortcontroller-polyfill@npm:1.7.5"
-  checksum: daf4169f4228ae0e4f4dbcfa782e501b923667f2666b7c55bd3b7664e5d6b100e333a93371173985fdf21f65d7dfba15bdb2e6031bdc9e57e4ce0297147da3aa
   languageName: node
   linkType: hard
 
@@ -818,7 +839,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
+"ansi-styles@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "ansi-styles@npm:3.2.1"
+  dependencies:
+    color-convert: ^1.9.0
+  checksum: d85ade01c10e5dd77b6c89f34ed7531da5830d2cb5882c645f330079975b716438cd7ebb81d0d6e6b4f9c577f19ae41ab55f07f19786b02f9dfd9e0377395665
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.0.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -851,28 +881,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autometrics-monorepo@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "autometrics-monorepo@workspace:."
-  dependencies:
-    "@parcel/types": ^2.10.0
-    typescript: ^5.2.2
-  languageName: unknown
-  linkType: soft
-
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
-  languageName: node
-  linkType: hard
-
-"base-x@npm:^3.0.8":
-  version: 3.0.9
-  resolution: "base-x@npm:3.0.9"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: 957101d6fd09e1903e846fd8f69fd7e5e3e50254383e61ab667c725866bec54e5ece5ba49ce385128ae48f9ec93a26567d1d5ebb91f4d56ef4a9cc0d5a5481e8
   languageName: node
   linkType: hard
 
@@ -895,16 +907,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "braces@npm:3.0.2"
-  dependencies:
-    fill-range: ^7.0.1
-  checksum: e2a8e769a863f3d4ee887b5fe21f63193a891c68b612ddb4b68d82d1b5f3ff9073af066c343e9867a393fe4c2555dcb33e89b937195feb9c1613d259edfcd459
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.6.6":
+"browserslist@npm:^4.21.9":
   version: 4.22.1
   resolution: "browserslist@npm:4.22.1"
   dependencies:
@@ -939,19 +942,20 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001541":
-  version: 1.0.30001549
-  resolution: "caniuse-lite@npm:1.0.30001549"
-  checksum: 7f2abeedc8cf8b92cc0613855d71b995ce436068c0bcdd798c5af7d297ccf9f52496b00181beda42d82d25079dd4b6e389c67486156d40d8854e5707a25cb054
+  version: 1.0.30001553
+  resolution: "caniuse-lite@npm:1.0.30001553"
+  checksum: 45d6a2a3c3a098c8093a4c8883fceafb4bbf59d96f6fd5bb381ba4581d07eecbe0ede4f55383f0d49374154ff6a808bd90fbe32b17ccd1738034d2579787b33c
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.0":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
+"chalk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
   dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+    ansi-styles: ^3.2.1
+    escape-string-regexp: ^1.0.5
+    supports-color: ^5.3.0
+  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
   languageName: node
   linkType: hard
 
@@ -962,13 +966,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrome-trace-event@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "chrome-trace-event@npm:1.0.3"
-  checksum: cb8b1fc7e881aaef973bd0c4a43cd353c2ad8323fb471a041e64f7c2dd849cde4aad15f8b753331a32dda45c973f032c8a03b8177fc85d60eaa75e91e08bfb97
-  languageName: node
-  linkType: hard
-
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -976,10 +973,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "clone@npm:2.1.2"
-  checksum: aaf106e9bc025b21333e2f4c12da539b568db4925c0501a1bf4070836c9e848c892fa22c35548ce0d1132b08bbbfa17a00144fe58fccdab6fa900fec4250f67d
+"color-convert@npm:^1.9.0":
+  version: 1.9.3
+  resolution: "color-convert@npm:1.9.3"
+  dependencies:
+    color-name: 1.1.3
+  checksum: fd7a64a17cde98fb923b1dd05c5f2e6f7aefda1b60d67e8d449f9328b4e53b228a428fd38bfeaeb2db2ff6b6503a776a996150b80cdf224062af08a5c8a3a203
   languageName: node
   linkType: hard
 
@@ -989,6 +988,13 @@ __metadata:
   dependencies:
     color-name: ~1.1.4
   checksum: 79e6bdb9fd479a205c71d89574fccfb22bd9053bd98c6c4d870d65c132e5e904e6034978e55b43d69fcaa7433af2016ee203ce76eeba9cfa554b373e7f7db336
+  languageName: node
+  linkType: hard
+
+"color-name@npm:1.1.3":
+  version: 1.1.3
+  resolution: "color-name@npm:1.1.3"
+  checksum: 09c5d3e33d2105850153b14466501f2bfb30324a2f76568a408763a3b7433b0e50e5b4ab1947868e65cb101bb7cb75029553f2c333b6d4b8138a73fcc133d69d
   languageName: node
   linkType: hard
 
@@ -1022,6 +1028,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -1033,7 +1046,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.3":
+"csstype@npm:^3.0.2":
+  version: 3.1.2
+  resolution: "csstype@npm:3.1.2"
+  checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.3":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -1052,36 +1072,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "detect-libc@npm:1.0.3"
-  bin:
-    detect-libc: ./bin/detect-libc.js
-  checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
-  languageName: node
-  linkType: hard
-
-"detect-libc@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "detect-libc@npm:2.0.2"
-  checksum: 2b2cd3649b83d576f4be7cc37eb3b1815c79969c8b1a03a40a4d55d83bc74d010753485753448eacb98784abf22f7dbd3911fd3b60e29fda28fed2d1a997944d
-  languageName: node
-  linkType: hard
-
-"dotenv-expand@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "dotenv-expand@npm:5.1.0"
-  checksum: 8017675b7f254384915d55f9eb6388e577cf0a1231a28d54b0ca03b782be9501b0ac90ac57338636d395fa59051e6209e9b44b8ddf169ce6076dffb5dea227d3
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "dotenv@npm:7.0.0"
-  checksum: 18a7b3ef0e90fd6fcce7c7cbdd48d923b0cb180807540b80c797bda4a098097e17820d6315ae28eec22f73954cd0ab9d81904d46370183817c09f694d40566ff
-  languageName: node
-  linkType: hard
-
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -1090,9 +1080,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.535":
-  version: 1.4.556
-  resolution: "electron-to-chromium@npm:1.4.556"
-  checksum: 8c9aa48776d80c23d8709dcd4342f1b18ca5b63bdb233fb6913f0db7b382d69afa84d5f08ead84bde6378a6a7ab3d1127f7cb6f4d0642fa625e96de6559dc1d7
+  version: 1.4.565
+  resolution: "electron-to-chromium@npm:1.4.565"
+  checksum: 5baa0ea0b53fea50f66668e5d61b0a5418f5925a88737fbfbb1cfb991e0b9b5de32479807d70413f8c46b9f3d08e87ad567c032bf36305f212da54fcb20bb355
   languageName: node
   linkType: hard
 
@@ -1133,6 +1123,83 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:^0.18.10":
+  version: 0.18.20
+  resolution: "esbuild@npm:0.18.20"
+  dependencies:
+    "@esbuild/android-arm": 0.18.20
+    "@esbuild/android-arm64": 0.18.20
+    "@esbuild/android-x64": 0.18.20
+    "@esbuild/darwin-arm64": 0.18.20
+    "@esbuild/darwin-x64": 0.18.20
+    "@esbuild/freebsd-arm64": 0.18.20
+    "@esbuild/freebsd-x64": 0.18.20
+    "@esbuild/linux-arm": 0.18.20
+    "@esbuild/linux-arm64": 0.18.20
+    "@esbuild/linux-ia32": 0.18.20
+    "@esbuild/linux-loong64": 0.18.20
+    "@esbuild/linux-mips64el": 0.18.20
+    "@esbuild/linux-ppc64": 0.18.20
+    "@esbuild/linux-riscv64": 0.18.20
+    "@esbuild/linux-s390x": 0.18.20
+    "@esbuild/linux-x64": 0.18.20
+    "@esbuild/netbsd-x64": 0.18.20
+    "@esbuild/openbsd-x64": 0.18.20
+    "@esbuild/sunos-x64": 0.18.20
+    "@esbuild/win32-arm64": 0.18.20
+    "@esbuild/win32-ia32": 0.18.20
+    "@esbuild/win32-x64": 0.18.20
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 5d253614e50cdb6ec22095afd0c414f15688e7278a7eb4f3720a6dd1306b0909cf431e7b9437a90d065a31b1c57be60130f63fe3e8d0083b588571f31ee6ec7b
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -1140,19 +1207,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "escape-string-regexp@npm:1.0.5"
+  checksum: 6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
+  languageName: node
+  linkType: hard
+
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 3d21519a4f8207c99f7457287291316306255a328770d320b401114ec8481986e4e467e854cb9914dd965e0a1ca810a23ccb559c642c88f4c7f55c55778a9b48
-  languageName: node
-  linkType: hard
-
-"fill-range@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "fill-range@npm:7.0.1"
-  dependencies:
-    to-regex-range: ^5.0.1
-  checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
   languageName: node
   linkType: hard
 
@@ -1191,6 +1256,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:~2.3.2":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: latest
+  checksum: 11e6ea6fea15e42461fc55b4b0e4a0a3c654faa567f1877dbd353f39156f69def97a69936d1746619d656c4b93de2238bf731f6085a03a50cabf287c9d024317
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#~builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  dependencies:
+    node-gyp: latest
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "gauge@npm:^4.0.3":
   version: 4.0.4
   resolution: "gauge@npm:4.0.4"
@@ -1204,6 +1288,13 @@ __metadata:
     strip-ansi: ^6.0.1
     wide-align: ^1.1.5
   checksum: 788b6bfe52f1dd8e263cda800c26ac0ca2ff6de0b6eee2fe0d9e3abf15e149b651bd27bf5226be10e6e3edb5c4e5d5985a5a1a98137e7a892f75eff76467ad2d
+  languageName: node
+  linkType: hard
+
+"gensync@npm:^1.0.0-beta.2":
+  version: 1.0.0-beta.2
+  resolution: "gensync@npm:1.0.0-beta.2"
+  checksum: a7437e58c6be12aa6c90f7730eac7fa9833dc78872b4ad2963d2031b00a3367a93f98aec75f9aaac7220848e4026d67a8655e870b24f20a543d103c0d65952ec
   languageName: node
   linkType: hard
 
@@ -1236,6 +1327,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globals@npm:^11.1.0":
+  version: 11.12.0
+  resolution: "globals@npm:11.12.0"
+  checksum: 67051a45eca3db904aee189dfc7cd53c20c7d881679c93f6146ddd4c9f4ab2268e68a919df740d39c71f4445d2b38ee360fc234428baea1dbdfe68bbcb46979e
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -1243,10 +1341,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "has-flag@npm:4.0.0"
-  checksum: 261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
   languageName: node
   linkType: hard
 
@@ -1341,13 +1439,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-extglob@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "is-extglob@npm:2.1.1"
-  checksum: df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
-  languageName: node
-  linkType: hard
-
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
@@ -1355,26 +1446,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "is-glob@npm:4.0.3"
-  dependencies:
-    is-extglob: ^2.1.1
-  checksum: d381c1319fcb69d341cc6e6c7cd588e17cd94722d9a32dbd60660b993c4fb7d0f19438674e68dfec686d09b7c73139c9166b47597f846af387450224a8101ab4
-  languageName: node
-  linkType: hard
-
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 93a32f01940220532e5948538699ad610d5924ac86093fcee83022252b363eb0cc99ba53ab084a04e4fb62bf7b5731f55496257a4c38adf87af9c4d352c71c35
-  languageName: node
-  linkType: hard
-
-"is-number@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "is-number@npm:7.0.0"
-  checksum: 456ac6f8e0f3111ed34668a624e45315201dff921e5ac181f8ec24923b99e9f32ca1a194912dc79d539c97d33dba17dc635202ff0b2cf98326f608323276d27a
   languageName: node
   linkType: hard
 
@@ -1398,7 +1473,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.0, json5@npm:^2.2.1":
+"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "js-tokens@npm:4.0.0"
+  checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
+  languageName: node
+  linkType: hard
+
+"jsesc@npm:^2.5.1":
+  version: 2.5.2
+  resolution: "jsesc@npm:2.5.2"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 4dc190771129e12023f729ce20e1e0bfceac84d73a85bc3119f7f938843fe25a4aeccb54b6494dce26fcf263d815f5f31acdefac7cc9329efb8422a4f4d9fa9d
+  languageName: node
+  linkType: hard
+
+"json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -1407,45 +1498,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lmdb@npm:2.8.5":
-  version: 2.8.5
-  resolution: "lmdb@npm:2.8.5"
-  dependencies:
-    "@lmdb/lmdb-darwin-arm64": 2.8.5
-    "@lmdb/lmdb-darwin-x64": 2.8.5
-    "@lmdb/lmdb-linux-arm": 2.8.5
-    "@lmdb/lmdb-linux-arm64": 2.8.5
-    "@lmdb/lmdb-linux-x64": 2.8.5
-    "@lmdb/lmdb-win32-x64": 2.8.5
-    msgpackr: ^1.9.5
-    node-addon-api: ^6.1.0
-    node-gyp: latest
-    node-gyp-build-optional-packages: 5.1.1
-    ordered-binary: ^1.4.1
-    weak-lru-cache: ^1.2.2
-  dependenciesMeta:
-    "@lmdb/lmdb-darwin-arm64":
-      optional: true
-    "@lmdb/lmdb-darwin-x64":
-      optional: true
-    "@lmdb/lmdb-linux-arm":
-      optional: true
-    "@lmdb/lmdb-linux-arm64":
-      optional: true
-    "@lmdb/lmdb-linux-x64":
-      optional: true
-    "@lmdb/lmdb-win32-x64":
-      optional: true
-  bin:
-    download-lmdb-prebuilds: bin/download-prebuilds.js
-  checksum: b1ec76650d3b19d4c966cd7a4ee2324270c7d20f46b569d23bc287c7c7e7da667d3d330aa78be1aa2717af63b3531cd1d53a5ee4faf1c293c038513e4f3aa832
-  languageName: node
-  linkType: hard
-
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"loose-envify@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "loose-envify@npm:1.4.0"
+  dependencies:
+    js-tokens: ^3.0.0 || ^4.0.0
+  bin:
+    loose-envify: cli.js
+  checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "lru-cache@npm:5.1.1"
+  dependencies:
+    yallist: ^3.0.2
+  checksum: c154ae1cbb0c2206d1501a0e94df349653c92c8cbb25236d7e85190bcaf4567a03ac6eb43166fabfa36fd35623694da7233e88d9601fbf411a9a481d85dbd2cb
   languageName: node
   linkType: hard
 
@@ -1472,6 +1548,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "magic-string@npm:0.27.0"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.13
+  checksum: 273faaa50baadb7a2df6e442eac34ad611304fc08fe16e24fe2e472fd944bfcb73ffb50d2dc972dc04e92784222002af46868cb9698b1be181c81830fd95a13e
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^11.0.3":
   version: 11.1.1
   resolution: "make-fetch-happen@npm:11.1.1"
@@ -1492,16 +1577,6 @@ __metadata:
     socks-proxy-agent: ^7.0.0
     ssri: ^10.0.0
   checksum: 7268bf274a0f6dcf0343829489a4506603ff34bd0649c12058753900b0eb29191dce5dba12680719a5d0a983d3e57810f594a12f3c18494e93a1fbc6348a4540
-  languageName: node
-  linkType: hard
-
-"micromatch@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "micromatch@npm:4.0.5"
-  dependencies:
-    braces: ^3.0.2
-    picomatch: ^2.3.1
-  checksum: 02a17b671c06e8fefeeb6ef996119c1e597c942e632a21ef589154f23898c9c6a9858526246abb14f8bca6e77734aa9dcf65476fca47cedfb80d9577d52843fc
   languageName: node
   linkType: hard
 
@@ -1630,46 +1705,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msgpackr-extract@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "msgpackr-extract@npm:3.0.2"
-  dependencies:
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64": 3.0.2
-    "@msgpackr-extract/msgpackr-extract-darwin-x64": 3.0.2
-    "@msgpackr-extract/msgpackr-extract-linux-arm": 3.0.2
-    "@msgpackr-extract/msgpackr-extract-linux-arm64": 3.0.2
-    "@msgpackr-extract/msgpackr-extract-linux-x64": 3.0.2
-    "@msgpackr-extract/msgpackr-extract-win32-x64": 3.0.2
-    node-gyp: latest
-    node-gyp-build-optional-packages: 5.0.7
-  dependenciesMeta:
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64":
-      optional: true
-    "@msgpackr-extract/msgpackr-extract-darwin-x64":
-      optional: true
-    "@msgpackr-extract/msgpackr-extract-linux-arm":
-      optional: true
-    "@msgpackr-extract/msgpackr-extract-linux-arm64":
-      optional: true
-    "@msgpackr-extract/msgpackr-extract-linux-x64":
-      optional: true
-    "@msgpackr-extract/msgpackr-extract-win32-x64":
-      optional: true
+"nanoid@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "nanoid@npm:3.3.6"
   bin:
-    download-msgpackr-prebuilds: bin/download-prebuilds.js
-  checksum: 5adb809b965bac41c310e60373d54c955fe78e4d134ab036d0f9ee5b322cec0a739878d395e17c1ac82d840705896b2dafae6a8cc04ad34c14d2de4b06b58330
-  languageName: node
-  linkType: hard
-
-"msgpackr@npm:^1.5.4, msgpackr@npm:^1.9.5":
-  version: 1.9.9
-  resolution: "msgpackr@npm:1.9.9"
-  dependencies:
-    msgpackr-extract: ^3.0.2
-  dependenciesMeta:
-    msgpackr-extract:
-      optional: true
-  checksum: b63182d99f479d79f0d082fd2688ce7cf699b1aee71e20f28591c30b48743bb57868fdd72656759a892891072d186d864702c756434520709e8fe7e0d350a119
+    nanoid: bin/nanoid.cjs
+  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
   languageName: node
   linkType: hard
 
@@ -1677,48 +1718,6 @@ __metadata:
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: b8ffeb1e262eff7968fc90a2b6767b04cfd9842582a9d0ece0af7049537266e7b2506dfb1d107a32f06dd849ab2aea834d5830f7f4d0e5cb7d36e1ae55d021d9
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "node-addon-api@npm:6.1.0"
-  dependencies:
-    node-gyp: latest
-  checksum: 3a539510e677cfa3a833aca5397300e36141aca064cdc487554f2017110709a03a95da937e98c2a14ec3c626af7b2d1b6dabe629a481f9883143d0d5bff07bf2
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "node-addon-api@npm:7.0.0"
-  dependencies:
-    node-gyp: latest
-  checksum: 4349465d737e284b280fc0e5fd2384f9379bca6b7f2a5a1460bea676ba5b90bf563e7d02a9254c35b9ed808641c81d9b4ca9e1da17d2849cd07727660b00b332
-  languageName: node
-  linkType: hard
-
-"node-gyp-build-optional-packages@npm:5.0.7":
-  version: 5.0.7
-  resolution: "node-gyp-build-optional-packages@npm:5.0.7"
-  bin:
-    node-gyp-build-optional-packages: bin.js
-    node-gyp-build-optional-packages-optional: optional.js
-    node-gyp-build-optional-packages-test: build-test.js
-  checksum: bcb4537af15bcb3811914ea0db8f69284ca10db1cc7543a167a4c41ae4b9b5044b133f789fdadad0b7adc6931f6ae7def3c75b0bc7b05836881aae52400163e6
-  languageName: node
-  linkType: hard
-
-"node-gyp-build-optional-packages@npm:5.1.1":
-  version: 5.1.1
-  resolution: "node-gyp-build-optional-packages@npm:5.1.1"
-  dependencies:
-    detect-libc: ^2.0.1
-  bin:
-    node-gyp-build-optional-packages: bin.js
-    node-gyp-build-optional-packages-optional: optional.js
-    node-gyp-build-optional-packages-test: build-test.js
-  checksum: f3cb197862516e6879377adaa58142ae9013ab69c86cf2645f8b008db339354145d8ebd9140a13ec7ece5ce28a372ca7e14660379d3a3dd7b908a6f2743606e9
   languageName: node
   linkType: hard
 
@@ -1773,26 +1772,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nullthrows@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "nullthrows@npm:1.1.1"
-  checksum: 10806b92121253eb1b08ecf707d92480f5331ba8ae5b23fa3eb0548ad24196eb797ed47606153006568a5733ea9e528a3579f21421f7828e09e7756f4bdd386f
-  languageName: node
-  linkType: hard
-
 "once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
-  languageName: node
-  linkType: hard
-
-"ordered-binary@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "ordered-binary@npm:1.4.1"
-  checksum: 274940b4ef983562e11371c84415c265432a4e1337ab85f8e7669eeab6afee8f655c6c12ecee1cd121aaf399c32f5c781b0d50e460bd42da004eba16dcc66574
   languageName: node
   linkType: hard
 
@@ -1836,10 +1821,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+"postcss@npm:^8.4.27":
+  version: 8.4.31
+  resolution: "postcss@npm:8.4.31"
+  dependencies:
+    nanoid: ^3.3.6
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 1d8611341b073143ad90486fcdfeab49edd243377b1f51834dc4f6d028e82ce5190e4f11bb2633276864503654fb7cab28e67abdc0fbf9d1f88cad4a0ff0beea
   languageName: node
   linkType: hard
 
@@ -1850,6 +1839,51 @@ __metadata:
     err-code: ^2.0.2
     retry: ^0.12.0
   checksum: f96a3f6d90b92b568a26f71e966cbbc0f63ab85ea6ff6c81284dc869b41510e6cdef99b6b65f9030f0db422bf7c96652a3fff9f2e8fb4a0f069d8f4430359429
+  languageName: node
+  linkType: hard
+
+"react-app-example@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "react-app-example@workspace:."
+  dependencies:
+    "@autometrics/autometrics": "portal:../../dist/autometrics"
+    "@autometrics/exporter-otlp-http": "portal:../../dist/exporter-otlp-http"
+    "@autometrics/typescript-plugin": ^0.5.4
+    "@types/react": ^18.0.27
+    "@types/react-dom": ^18.0.10
+    "@vitejs/plugin-react": ^3.1.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    typescript: ^5.2.2
+    vite: ^4.5.0
+  languageName: unknown
+  linkType: soft
+
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.0
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+  languageName: node
+  linkType: hard
+
+"react-refresh@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "react-refresh@npm:0.14.0"
+  checksum: dc69fa8c993df512f42dd0f1b604978ae89bd747c0ed5ec595c0cc50d535fb2696619ccd98ae28775cc01d0a7c146a532f0f7fb81dc22e1977c242a4912312f4
+  languageName: node
+  linkType: hard
+
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -1882,7 +1916,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
+"rollup@npm:^3.27.1":
+  version: 3.29.4
+  resolution: "rollup@npm:3.29.4"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 8bb20a39c8d91130825159c3823eccf4dc2295c9a0a5c4ed851a5bf2167dbf24d9a29f23461a54c955e5506395e6cc188eafc8ab0e20399d7489fb33793b184e
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -1896,7 +1944,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.2":
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
+  bin:
+    semver: bin/semver.js
+  checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.5":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -1972,6 +2038,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "source-map-js@npm:1.0.2"
+  checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^10.0.0":
   version: 10.0.5
   resolution: "ssri@npm:10.0.5"
@@ -2030,12 +2103,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "supports-color@npm:7.2.0"
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
   dependencies:
-    has-flag: ^4.0.0
-  checksum: 3dda818de06ebbe5b9653e07842d9479f3555ebc77e9a0280caf5a14fb877ffee9ed57007c3b78f5a6324b8dbeec648d9e97a24e2ed9fdb81ddc69ea07100f4a
+    has-flag: ^3.0.0
+  checksum: 95f6f4ba5afdf92f495b5a912d4abee8dcba766ae719b975c56c084f5004845f6f5a5f7769f52d53f40e21952a6d87411bafe34af4a01e65f9926002e38e1dac
   languageName: node
   linkType: hard
 
@@ -2053,16 +2126,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"to-regex-range@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "to-regex-range@npm:5.0.1"
-  dependencies:
-    is-number: ^7.0.0
-  checksum: f76fa01b3d5be85db6a2a143e24df9f60dd047d151062d0ba3df62953f2f697b16fe5dad9b0ac6191c7efc7b1d9dcaa4b768174b7b29da89d4428e64bc0a20ed
+"to-fast-properties@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "to-fast-properties@npm:2.0.0"
+  checksum: be2de62fe58ead94e3e592680052683b1ec986c72d589e7b21e5697f8744cdbf48c266fa72f6c15932894c10187b5f54573a3bcf7da0bfd964d5caf23d436168
   languageName: node
   linkType: hard
 
-"typescript@npm:>=5.0.4, typescript@npm:^5.0.4, typescript@npm:^5.2.2":
+"typescript@npm:^5.2.2":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
   bin:
@@ -2072,7 +2143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@>=5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.2.2
   resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
@@ -2121,17 +2192,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"utility-types@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "utility-types@npm:3.10.0"
-  checksum: 8f274415c6196ab62883b8bd98c9d2f8829b58016e4269aaa1ebd84184ac5dda7dc2ca45800c0d5e0e0650966ba063bf9a412aaeaea6850ca4440a391283d5c8
-  languageName: node
-  linkType: hard
-
-"weak-lru-cache@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "weak-lru-cache@npm:1.2.2"
-  checksum: 0fbe16839d193ed82ddb4fe331ca8cfaee2ecbd42596aa02366c708956cf41f7258f2d5411c3bc9aa099c26058dc47afbd2593d449718a18e4ef4d870c5ace18
+"vite@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "vite@npm:4.5.0"
+  dependencies:
+    esbuild: ^0.18.10
+    fsevents: ~2.3.2
+    postcss: ^8.4.27
+    rollup: ^3.27.1
+  peerDependencies:
+    "@types/node": ">= 14"
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 06f1a4c858e4dc4c04a10466f4ccacea30c5a9f8574e5ba3deb9d03fa20e80ca6797f02dad97a988da7cdef96238dbc69c3b6a538156585c74722d996223619e
   languageName: node
   linkType: hard
 
@@ -2181,6 +2278,13 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^3.0.2":
+  version: 3.1.1
+  resolution: "yallist@npm:3.1.1"
+  checksum: 48f7bb00dc19fc635a13a39fe547f527b10c9290e7b3e836b9a8f1ca04d4d342e85714416b3c2ab74949c9c66f9cebb0473e6bc353b79035356103b47641285d
   languageName: node
   linkType: hard
 

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ test_permissions := "--allow-env --allow-net --allow-read --allow-sys"
 build: (build-npm "")
 
 build-npm version:
-    deno run --allow-env --allow-net=deno.land --allow-read --allow-run=yarn --allow-write=dist scripts/build_npm.ts {{version}}
+    deno run --allow-env --allow-ffi --allow-net=deno.land --allow-read --allow-run --allow-sys --allow-write=dist scripts/build_npm.ts {{version}}
 
 build-examples:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -2,13 +2,13 @@ alias b := build
 alias l := lint
 alias t := test
 
-examples := "deno-fresh express faas-experimental fastify hono-bun"
+examples := "deno-fresh express faas-experimental fastify hono-bun react-app-experimental"
 
 lib_packages := "autometrics exporter-otlp-http exporter-prometheus exporter-prometheus-push-gateway"
 
 test_permissions := "--allow-env --allow-net --allow-read --allow-sys"
 
-build: (build-npm "beta")
+build: (build-npm "")
 
 build-npm version:
     deno run --allow-env --allow-net=deno.land --allow-read --allow-run=yarn --allow-write=dist scripts/build_npm.ts {{version}}
@@ -74,7 +74,7 @@ type-check-typescript-plugin:
 type-check-all: type-check type-check-examples type-check-parcel-transformer type-check-typescript-plugin
 
 clean:
-    rm -Rf dist
+    rm -Rf dist node_modules
 
 clean-examples:
     for example in {{examples}}; do pushd "examples/$example"; just clean; popd; done

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "autometrics-monorepo",
   "packageManager": "yarn@3.6.3",
+  "version": "0.8.0-dev",
   "workspaces": [
     "dist/autometrics",
     "dist/exporter-otlp-http",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "packages/typescript-plugin"
   ],
   "devDependencies": {
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/core": "^1.17.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.43.0",
+    "@opentelemetry/exporter-prometheus": "^0.43.0",
+    "@opentelemetry/resources": "^1.17.0",
+    "@opentelemetry/sdk-metrics": "^1.17.0",
     "@parcel/types": "^2.10.0",
     "typescript": "^5.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "packages/typescript-plugin"
   ],
   "devDependencies": {
-    "@parcel/types": "^2.10.0"
+    "@parcel/types": "^2.10.0",
+    "typescript": "^5.2.2"
   },
   "resolutions": {
     "@opentelemetry/sdk-metrics": "1.17.1"

--- a/packages/autometrics/README.md
+++ b/packages/autometrics/README.md
@@ -7,6 +7,17 @@ This is the official TypeScript implementation for https://autometrics.dev/.
 Full documentation for the `@autometrics/autometrics` library can be found here:
 https://github.com/autometrics-dev/autometrics-ts
 
+## Installation
+
+Add the following mappings to your [import map](https://docs.deno.com/runtime/manual/basics/import_maps):
+
+```json
+{
+  "$autometrics/": "https://deno.land/x/autometrics/",
+  "$otel/": "npm:/@opentelemetry/",
+}
+```
+
 ## Recipe: Server-side example with Prometheus
 
 This recipe will start a webserver on port 9464, with a Prometheus-compatible
@@ -21,8 +32,8 @@ https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape
 1. Anywhere in your source code:
 
 ```typescript
-import { autometrics } from "https://deno.land/x/autometrics/mod.ts";
-import { init } from "https://deno.land/x/autometrics/exporter-prometheus.ts";
+import { autometrics } from "$autometrics/mod.ts";
+import { init } from "$autometrics/exporter-prometheus.ts";
 
 init(); // starts the webserver with the `/metrics` endpoint on port 9464
 
@@ -44,8 +55,8 @@ https://opentelemetry.io/docs/collector/getting-started/
 1. Anywhere in your source code:
 
 ```typescript
-import { autometrics } from "https://deno.land/x/autometrics/mod.ts";
-import { init } from "https://deno.land/x/autometrics/exporter-otlp-http.ts";
+import { autometrics } from "$autometrics/mod.ts";
+import { init } from "$autometrics/exporter-otlp-http.ts";
 
 init({ url: "https://<your-otel-collector>" });
 
@@ -67,8 +78,8 @@ gateway, such as: https://github.com/sinkingpoint/prometheus-gravel-gateway
 1. Anywhere in your source code:
 
 ```typescript
-import { autometrics } from "https://deno.land/x/autometrics/mod.ts";
-import { init } from "https://deno.land/x/autometrics/exporter-prometheus-push-gateway.ts";
+import { autometrics } from "$autometrics/mod.ts";
+import { init } from "$autometrics/exporter-prometheus-push-gateway.ts";
 
 init({ url: "https://<your-otel-collector>" });
 

--- a/packages/autometrics/src/buildInfo.ts
+++ b/packages/autometrics/src/buildInfo.ts
@@ -1,4 +1,4 @@
-import type { UpDownCounter } from "npm:@opentelemetry/api@^1.6.0";
+import type { UpDownCounter } from "$otel/api";
 
 import { BUILD_INFO_DESCRIPTION, BUILD_INFO_NAME } from "./constants.ts";
 import { getMeter } from "./instrumentation.ts";

--- a/packages/autometrics/src/buildInfo.ts
+++ b/packages/autometrics/src/buildInfo.ts
@@ -14,26 +14,34 @@ import { getBranch, getCommit, getVersion } from "./platform.deno.ts";
  */
 export type BuildInfo = {
   /**
-   * The current version of the application. Should be set through an
-   * environment variable: `AUTOMETRICS_VERSION` or `PACKAGE_VERSION`.
+   * The current version of the application.
+   *
+   * Should be set through the `AUTOMETRICS_VERSION` environment variable, or by
+   * explicitly specifying the `buildInfo` when calling `init()`.
    */
   version?: string;
 
   /**
-   * The current commit hash of the application. Should be set through an
-   * environment variable: `AUTOMETRICS_COMMIT` or `COMMIT_SHA`.
+   * The current commit hash of the application.
+   *
+   * Should be set through the `AUTOMETRICS_COMMIT` environment variable, or by
+   * explicitly specifying the `buildInfo` when calling `init()`.
    */
   commit?: string;
 
   /**
-   * The current commit hash of the application. Should be set through an
-   * environment variable: `AUTOMETRICS_BRANCH` or `BRANCH_NAME`.
+   * The current commit hash of the application.
+   *
+   * Should be set through the `AUTOMETRICS_BRANCH` environment variable, or by
+   * explicitly specifying the `buildInfo` when calling `init()`.
    */
   branch?: string;
 
   /**
    * The "clearmode" label of the `build_info` metric.
-   * This label is used when pushing to a Gravel Gateway
+   *
+   * Only used when pushing to a Gravel Gateway. Should be set by explicitly
+   * specifying the `buildInfo` when calling `init()`.
    *
    * When pushing to a Gravel Gateway, it's recommended to use the "family"
    * clearmode. See the Gravel Gateways documentation for more details.

--- a/packages/autometrics/src/exporter-otlp-http/mod.ts
+++ b/packages/autometrics/src/exporter-otlp-http/mod.ts
@@ -19,7 +19,7 @@ const MAX_SAFE_INTERVAL = 2 ** 31 - 1;
 export type InitOptions = {
   /**
    * URL of the OpenTelemetry Collector to push metrics to. Should be a
-   * complete url with port and `/v1/metrics` endpoint:
+   * complete URL with port and `/v1/metrics` endpoint:
    * `http://localhost:4317/v1/metrics`.
    */
   url: string;

--- a/packages/autometrics/src/exporter-otlp-http/mod.ts
+++ b/packages/autometrics/src/exporter-otlp-http/mod.ts
@@ -1,8 +1,8 @@
 import {
   AggregationTemporalityPreference,
   OTLPMetricExporter,
-} from "npm:@opentelemetry/exporter-metrics-otlp-http@^0.43.0";
-import { PeriodicExportingMetricReader } from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+} from "$otel/exporter-metrics-otlp-http";
+import { PeriodicExportingMetricReader } from "$otel/sdk-metrics";
 
 import {
   BuildInfo,

--- a/packages/autometrics/src/exporter-otlp-http/registerExporterInternal.ts
+++ b/packages/autometrics/src/exporter-otlp-http/registerExporterInternal.ts
@@ -1,4 +1,4 @@
-import { MetricReader } from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+import { MetricReader } from "$otel/sdk-metrics";
 
 import { ExporterOptions, registerExporter } from "../../mod.ts";
 

--- a/packages/autometrics/src/exporter-prometheus-push-gateway/fetch.ts
+++ b/packages/autometrics/src/exporter-prometheus-push-gateway/fetch.ts
@@ -1,0 +1,3 @@
+const fetch = global.fetch;
+
+export { fetch };

--- a/packages/autometrics/src/exporter-prometheus-push-gateway/mod.ts
+++ b/packages/autometrics/src/exporter-prometheus-push-gateway/mod.ts
@@ -1,4 +1,4 @@
-import { PeriodicExportingMetricReader } from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+import { PeriodicExportingMetricReader } from "$otel/sdk-metrics";
 
 import {
   BuildInfo,

--- a/packages/autometrics/src/exporter-prometheus-push-gateway/mod.ts
+++ b/packages/autometrics/src/exporter-prometheus-push-gateway/mod.ts
@@ -7,6 +7,7 @@ import {
   recordBuildInfo,
   registerExporter,
 } from "../../mod.ts";
+import { fetch } from "./fetch.ts";
 import { PushGatewayExporter } from "./pushGatewayExporter.ts";
 
 const MAX_SAFE_INTERVAL = 2 ** 31 - 1;

--- a/packages/autometrics/src/exporter-prometheus-push-gateway/pushGatewayExporter.ts
+++ b/packages/autometrics/src/exporter-prometheus-push-gateway/pushGatewayExporter.ts
@@ -1,14 +1,10 @@
-import {
-  BindOnceFuture,
-  ExportResult,
-  ExportResultCode,
-} from "npm:@opentelemetry/core@^1.17.0";
+import { BindOnceFuture, ExportResult, ExportResultCode } from "$otel/core";
 import {
   AggregationTemporality,
   InstrumentType,
   PushMetricExporter,
   ResourceMetrics,
-} from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+} from "$otel/sdk-metrics";
 
 import { amLogger } from "../../mod.ts";
 import { PrometheusSerializer } from "../exporter-prometheus/PrometheusSerializer.ts";

--- a/packages/autometrics/src/exporter-prometheus-push-gateway/pushGatewayExporter.ts
+++ b/packages/autometrics/src/exporter-prometheus-push-gateway/pushGatewayExporter.ts
@@ -7,6 +7,7 @@ import {
 } from "$otel/sdk-metrics";
 
 import { amLogger } from "../../mod.ts";
+import { fetch } from "./fetch.ts";
 import { PrometheusSerializer } from "../exporter-prometheus/PrometheusSerializer.ts";
 import type { InitOptions } from "./mod.ts";
 

--- a/packages/autometrics/src/exporter-prometheus-push-gateway/pushGatewayExporter.ts
+++ b/packages/autometrics/src/exporter-prometheus-push-gateway/pushGatewayExporter.ts
@@ -7,8 +7,8 @@ import {
 } from "$otel/sdk-metrics";
 
 import { amLogger } from "../../mod.ts";
-import { fetch } from "./fetch.ts";
 import { PrometheusSerializer } from "../exporter-prometheus/PrometheusSerializer.ts";
+import { fetch } from "./fetch.ts";
 import type { InitOptions } from "./mod.ts";
 
 const serializer = new PrometheusSerializer();

--- a/packages/autometrics/src/exporter-prometheus/PrometheusExporter.ts
+++ b/packages/autometrics/src/exporter-prometheus/PrometheusExporter.ts
@@ -18,7 +18,7 @@ import {
   Aggregation,
   AggregationTemporality,
   MetricReader,
-} from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+} from "$otel/sdk-metrics";
 
 import { amLogger } from "../../mod.ts";
 import { PrometheusSerializer } from "./PrometheusSerializer.ts";

--- a/packages/autometrics/src/exporter-prometheus/PrometheusSerializer.ts
+++ b/packages/autometrics/src/exporter-prometheus/PrometheusSerializer.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { AttributeValue, Attributes } from "npm:@opentelemetry/api@^1.6.0";
-import { hrTimeToMilliseconds } from "npm:@opentelemetry/core@^1.17.0";
-import type { IResource } from "npm:@opentelemetry/resources@^1.17.0";
+import type { AttributeValue, Attributes } from "$otel/api";
+import { hrTimeToMilliseconds } from "$otel/core";
+import type { IResource } from "$otel/resources";
 import {
   DataPoint,
   DataPointType,
@@ -25,7 +25,7 @@ import {
   MetricData,
   ResourceMetrics,
   ScopeMetrics,
-} from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+} from "$otel/sdk-metrics";
 
 import { amLogger } from "../../mod.ts";
 

--- a/packages/autometrics/src/exporter-prometheus/mod.ts
+++ b/packages/autometrics/src/exporter-prometheus/mod.ts
@@ -1,4 +1,4 @@
-import { MetricReader } from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+import { MetricReader } from "$otel/sdk-metrics";
 
 import {
   BuildInfo,

--- a/packages/autometrics/src/histograms.ts
+++ b/packages/autometrics/src/histograms.ts
@@ -1,7 +1,4 @@
-import {
-  ExplicitBucketHistogramAggregation,
-  View,
-} from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+import { ExplicitBucketHistogramAggregation, View } from "$otel/sdk-metrics";
 
 import { HISTOGRAM_NAME } from "./constants.ts";
 

--- a/packages/autometrics/src/instrumentation.ts
+++ b/packages/autometrics/src/instrumentation.ts
@@ -1,8 +1,5 @@
-import type { Meter } from "npm:@opentelemetry/api@^1.6.0";
-import {
-  MeterProvider,
-  MetricReader,
-} from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+import type { Meter } from "$otel/api";
+import { MeterProvider, MetricReader } from "$otel/sdk-metrics";
 
 import { createDefaultHistogramView } from "./histograms.ts";
 import { TemporaryMeter } from "./temporaryMeter.ts";

--- a/packages/autometrics/src/platform.deno.ts
+++ b/packages/autometrics/src/platform.deno.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /**
  * Returns the version of the application, based on environment variables.
  *
@@ -34,4 +36,24 @@ export function getBranch(): string | undefined {
  */
 export function getCwd(): string {
   return Deno.cwd();
+}
+
+/**
+ * Caller information we track across async function calls.
+ *
+ * @internal
+ */
+export type AsyncContext = { caller?: string };
+
+/**
+ * Returns a new `AsyncLocalStorage` instance for storing caller information.
+ *
+ * Note: We include `undefined` in the return type since the web version of
+ * this function won't return anything. This way, we force ourselves to apply
+ * guards whenever we call this function.
+ *
+ * @internal
+ */
+export function getALSInstance(): AsyncLocalStorage<AsyncContext> | undefined {
+  return new AsyncLocalStorage<AsyncContext>();
 }

--- a/packages/autometrics/src/platform.deno.ts
+++ b/packages/autometrics/src/platform.deno.ts
@@ -43,7 +43,7 @@ export function getCwd(): string {
  *
  * @internal
  */
-export type AsyncContext = { caller?: string };
+export type AsyncContext = { callerFunction?: string; callerModule?: string };
 
 /**
  * Returns a new `AsyncLocalStorage` instance for storing caller information.

--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -58,5 +58,8 @@ export function getCwd(): string {
  * @internal
  */
 export function getALSInstance() {
-  return new AsyncLocalStorage<{ caller?: string }>();
+  return new AsyncLocalStorage<{
+    callerFunction?: string;
+    callerModule?: string;
+  }>();
 }

--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -1,12 +1,22 @@
+// NOTE: Node type definitions are not installed on purpose to prevent
+// accidental usage outside this file. As a result, there's quite a few
+// @ts-ignore statements in this file...
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /**
  * Returns the version of the application, based on environment variables.
  *
  * @internal
  */
 export function getVersion(): string | undefined {
-  const env = getEnv();
   return (
-    env.npm_package_version || env.PACKAGE_VERSION || env.AUTOMETRICS_VERSION
+    // @ts-ignore
+    process.env.AUTOMETRICS_VERSION ||
+    // @ts-ignore
+    process.env.npm_package_version ||
+    // @ts-ignore
+    process.env.PACKAGE_VERSION
   );
 }
 
@@ -17,8 +27,8 @@ export function getVersion(): string | undefined {
  * @internal
  */
 export function getCommit(): string | undefined {
-  const env = getEnv();
-  return env.COMMIT_SHA || env.AUTOMETRICS_COMMIT;
+  // @ts-ignore
+  return process.env.AUTOMETRICS_COMMIT || process.env.COMMIT_SHA;
 }
 
 /**
@@ -28,8 +38,8 @@ export function getCommit(): string | undefined {
  * @internal
  */
 export function getBranch(): string | undefined {
-  const env = getEnv();
-  return env.BRANCH_NAME || env.AUTOMETRICS_BRANCH;
+  // @ts-ignore
+  return process.env.AUTOMETRICS_BRANCH || process.env.BRANCH_NAME;
 }
 
 /**
@@ -38,13 +48,15 @@ export function getBranch(): string | undefined {
  * @internal
  */
 export function getCwd(): string {
-  // @ts-ignore Node type definitions are not installed on purpose to prevent
-  // accidental usage outside this file.
-  return ("process" in globalThis && process.cwd?.()) || "";
+  // @ts-ignore
+  return process.cwd();
 }
 
-function getEnv(): Record<string, string> {
-  // @ts-ignore Node type definitions are not installed on purpose to prevent
-  // accidental usage outside this file.
-  return ("process" in globalThis && process.env) || {};
+/**
+ * Returns a new `AsyncLocalStorage` instance for storing caller information.
+ *
+ * @internal
+ */
+export function getALSInstance() {
+  return new AsyncLocalStorage<{ caller?: string }>();
 }

--- a/packages/autometrics/src/platform.web.ts
+++ b/packages/autometrics/src/platform.web.ts
@@ -1,0 +1,44 @@
+/**
+ * On web, environment variables don't exist, so we return an empty string.
+ *
+ * @internal
+ */
+export function getVersion(): string | undefined {
+  return "";
+}
+
+/**
+ * On web, environment variables don't exist, so we return an empty string.
+ *
+ * @internal
+ */
+export function getCommit(): string | undefined {
+  return "";
+}
+
+/**
+ * On web, environment variables don't exist, so we return an empty string.
+ *
+ * @internal
+ */
+export function getBranch(): string | undefined {
+  return "";
+}
+
+/**
+ * On web, there's no concept of a working directory, so we return an empty
+ * string.
+ *
+ * @internal
+ */
+export function getCwd(): string {
+  return "";
+}
+
+/**
+ * `AsyncLocalStorage` is not supported on web, so we don't return anything.
+ *
+ * TODO: We should keep an eye on https://github.com/tc39/proposal-async-context
+ * to see if or when similar functionality gets supported on web.
+ */
+export function getALSInstance() {}

--- a/packages/autometrics/src/temporaryMeter.ts
+++ b/packages/autometrics/src/temporaryMeter.ts
@@ -13,7 +13,7 @@ import {
   ObservableUpDownCounter,
   UpDownCounter,
   createNoopMeter,
-} from "npm:@opentelemetry/api@^1.6.0";
+} from "$otel/api";
 
 import { warn } from "./logger.ts";
 

--- a/packages/autometrics/src/utils.ts
+++ b/packages/autometrics/src/utils.ts
@@ -4,27 +4,30 @@ import { getCwd } from "./platform.deno.ts";
 // given function e.g.: dist/index.js
 export function getModulePath(): string | undefined {
   let wrappedFunctionPath = getWrappedFunctionPath();
+  if (!wrappedFunctionPath) {
+    return;
+  }
 
   // check if the string is wrapped in parenthesis, if so, remove them
-  if (wrappedFunctionPath?.startsWith("(")) {
+  if (wrappedFunctionPath.startsWith("(")) {
     wrappedFunctionPath = wrappedFunctionPath.slice(1, -1);
   }
 
-  // If the path contains file:// protocol we need to remove it
-  if (wrappedFunctionPath?.includes("file://")) {
-    wrappedFunctionPath = wrappedFunctionPath.replace("file://", "");
+  // If the path starts with file:// protocol we need to remove it
+  if (wrappedFunctionPath.startsWith("file://")) {
+    wrappedFunctionPath = wrappedFunctionPath.slice(7);
   }
 
-  // if the path contains the column/line number we need to remove it
-
-  if (wrappedFunctionPath?.includes(":")) {
-    wrappedFunctionPath = wrappedFunctionPath.slice(
-      0,
-      wrappedFunctionPath.indexOf(":"),
-    );
+  // If the path contains the column/line number we need to remove it
+  const colonIndex = wrappedFunctionPath.indexOf(":");
+  if (colonIndex > -1) {
+    wrappedFunctionPath = wrappedFunctionPath.slice(0, colonIndex);
   }
 
-  wrappedFunctionPath = wrappedFunctionPath?.replace(getCwd(), "");
+  const cwd = getCwd();
+  if (wrappedFunctionPath.startsWith(cwd)) {
+    wrappedFunctionPath = wrappedFunctionPath.slice(cwd.length);
+  }
 
   return wrappedFunctionPath;
 }
@@ -44,14 +47,8 @@ function getWrappedFunctionPath(): string | undefined {
       file: callSite.getFileName(),
     }));
 
-    if (!stack) {
-      return;
-    }
-
-    // First checks if it is a TypeScript legacy decorator, and returns the
-    // file path in which the decorator is defined if it is. Otherwise it
-    // returns the first file path from the 4th call in the stack trace which
-    // does not point to our `wrappers.ts`.
+    // Returns the first file path from the 4th call in the stack trace which
+    // does not point to Autometrics itself.
     //
     // 0: getWrappedFunctionPath
     // 1: getModulePath
@@ -59,22 +56,21 @@ function getWrappedFunctionPath(): string | undefined {
     // 3: ... -> 4th call is the original wrapped function, but may be wrapped
     //           by a decorator still.
 
-    const call =
-      stack.find((call) => call.name?.includes("__decorate")) ??
-      stack
-        .slice(3)
-        .find(
-          (call) =>
-            call.file &&
-            !call.file.includes("wrappers.ts") &&
-            !call.file.includes("wrappers.js"),
-        );
+    const call = stack.find((call, index) => {
+      const { file } = call;
+      return (
+        index > 2 &&
+        file &&
+        !file.includes("autometrics/index.cjs") &&
+        !file.includes("autometrics/index.mjs") &&
+        !file.includes("wrappers.ts") &&
+        !file.includes("wrappers.js")
+      );
+    });
     return call?.file;
   } else {
-    // First checks if it is a TypeScript legacy decorator, and returns the
-    // file path in which the decorator is defined if it is. Otherwise it
-    // returns the first file path from the 5th line in the stack trace which
-    // does not point to our `wrappers.ts`.
+    // Returns the first file path from the 5th line in the stack trace which
+    // does not point to Autometrics itself.
     //
     // 0: Error
     // 1: at getWrappedFunctionPath ...
@@ -89,14 +85,14 @@ function getWrappedFunctionPath(): string | undefined {
     }
 
     const lines = stack.split("\n");
-    const line =
-      lines.find((line) => line.startsWith("at __decorate ")) ??
-      lines
-        .slice(4)
-        .find(
-          (line) =>
-            !line.includes("wrappers.ts") && !line.includes("wrappers.js"),
-        );
+    const line = lines.find(
+      (line, index) =>
+        index > 3 &&
+        !line.includes("autometrics/index.cjs") &&
+        !line.includes("autometrics/index.mjs") &&
+        !line.includes("wrappers.ts") &&
+        !line.includes("wrappers.js"),
+    );
 
     // Last space-separated item on the line is the path.
     const path = line?.trim().split(" ").pop();

--- a/packages/autometrics/src/utils.ts
+++ b/packages/autometrics/src/utils.ts
@@ -29,24 +29,6 @@ export function getModulePath(): string | undefined {
   return wrappedFunctionPath;
 }
 
-type ALSContext = {
-  caller?: string;
-};
-
-export type ALSInstance = Awaited<ReturnType<typeof getALSInstance>>;
-
-export async function getALSInstance() {
-  const { AsyncLocalStorage } = await import("node:async_hooks");
-  return new AsyncLocalStorage<ALSContext>();
-}
-
-export function getALSCaller(context?: ALSInstance) {
-  if (context) {
-    const contextValue = context.getStore();
-    return contextValue?.caller;
-  }
-}
-
 function getWrappedFunctionPath(): string | undefined {
   if ("prepareStackTrace" in Error) {
     const defaultPrepareStackTrace = Error.prepareStackTrace;

--- a/packages/autometrics/src/wrappers.ts
+++ b/packages/autometrics/src/wrappers.ts
@@ -9,25 +9,13 @@ import {
   HISTOGRAM_DESCRIPTION,
   HISTOGRAM_NAME,
 } from "./constants.ts";
+import { getALSInstance } from "./platform.deno.ts";
 import { getMeter, metricsRecorded } from "./instrumentation.ts";
+import { getModulePath, isFunction, isObject, isPromise } from "./utils.ts";
 import { trace, warn } from "./logger.ts";
 import type { Objective } from "./objectives.ts";
-import {
-  ALSInstance,
-  getALSCaller,
-  getALSInstance,
-  getModulePath,
-  isFunction,
-  isObject,
-  isPromise,
-} from "./utils.ts";
 
-let asyncLocalStorage: ALSInstance | undefined;
-if (typeof window === "undefined") {
-  (async () => {
-    asyncLocalStorage = await getALSInstance();
-  })();
-}
+const asyncLocalStorage = getALSInstance();
 
 /**
  * Function Wrapper
@@ -291,7 +279,7 @@ export function autometrics<F extends FunctionSig>(
         valueType: ValueType.INT,
       })
     : null;
-  const caller = getALSCaller(asyncLocalStorage);
+  const caller = asyncLocalStorage?.getStore()?.caller;
 
   counter.add(0, {
     function: functionName,

--- a/packages/autometrics/src/wrappers.ts
+++ b/packages/autometrics/src/wrappers.ts
@@ -1,6 +1,5 @@
-import { Attributes, ValueType } from "npm:@opentelemetry/api@^1.6.0";
+import { Attributes, ValueType } from "$otel/api";
 
-import { amLogger } from "../mod.ts";
 import {
   COUNTER_DESCRIPTION,
   COUNTER_NAME,
@@ -517,9 +516,7 @@ export function Autometrics<T extends FunctionSig>(
       }
 
       default:
-        amLogger.warn(
-          "Autometrics decorator can only be used on classes and methods",
-        );
+        warn("Autometrics decorator can only be used on classes and methods");
     }
   };
 }

--- a/packages/autometrics/src/wrappers.ts
+++ b/packages/autometrics/src/wrappers.ts
@@ -279,13 +279,12 @@ export function autometrics<F extends FunctionSig>(
         valueType: ValueType.INT,
       })
     : null;
-  const caller = asyncLocalStorage?.getStore()?.caller;
 
   counter.add(0, {
     function: functionName,
     module: moduleName,
     result: "ok",
-    caller,
+    caller: "",
     ...counterObjectiveAttributes,
   });
 
@@ -295,6 +294,8 @@ export function autometrics<F extends FunctionSig>(
       function: functionName,
       module: moduleName,
     });
+
+    const caller = asyncLocalStorage?.getStore()?.caller ?? "";
 
     const onSuccess = () => {
       const autometricsDuration = (performance.now() - autometricsStart) / 1000;

--- a/packages/autometrics/src/wrappers.ts
+++ b/packages/autometrics/src/wrappers.ts
@@ -400,11 +400,9 @@ export function autometrics<F extends FunctionSig>(
       }
     }
 
-    if (asyncLocalStorage) {
-      return asyncLocalStorage.run({ caller: functionName }, instrumentedFn);
-    }
-
-    return instrumentedFn();
+    return asyncLocalStorage
+      ? asyncLocalStorage.run({ caller: functionName }, instrumentedFn)
+      : instrumentedFn();
   };
 }
 

--- a/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
+++ b/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
@@ -2,7 +2,8 @@ export const snapshot = {};
 
 snapshot[`OTLP/HTTP exporter 1`] = `
 {
-  caller: "",
+  caller_function: "",
+  caller_module: "",
   function: "foo",
   module: "/packages/autometrics/tests/otlpHttpExporter.test.ts",
   objective_name: "",

--- a/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
+++ b/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
@@ -2,7 +2,7 @@ export const snapshot = {};
 
 snapshot[`OTLP/HTTP exporter 1`] = `
 {
-  caller: undefined,
+  caller: "",
   function: "foo",
   module: "/packages/autometrics/tests/otlpHttpExporter.test.ts",
   objective_name: "",

--- a/packages/autometrics/tests/callerInfo.test.ts
+++ b/packages/autometrics/tests/callerInfo.test.ts
@@ -1,0 +1,59 @@
+import { assertMatch } from "$std/assert/mod.ts";
+
+import { autometrics } from "../src/wrappers.ts";
+
+import { collectAndSerialize, stepWithMetricReader } from "./testUtils.ts";
+
+Deno.test("Caller info test", async (t) => {
+  await stepWithMetricReader(
+    t,
+    "caller is tracked in synchronous call",
+    async (metricReader) => {
+      const foo = autometrics(function foo() {});
+
+      const bar = autometrics(function bar() {
+        foo();
+      });
+
+      bar();
+
+      const serialized = await collectAndSerialize(metricReader);
+
+      assertMatch(
+        serialized,
+        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      );
+      assertMatch(
+        serialized,
+        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      );
+    },
+  );
+
+  await stepWithMetricReader(
+    t,
+    "caller is tracked in asynchronous call",
+    async (metricReader) => {
+      const foo = autometrics(function foo() {
+        return Promise.resolve();
+      });
+
+      const bar = autometrics(async function bar() {
+        await foo();
+      });
+
+      await bar();
+
+      const serialized = await collectAndSerialize(metricReader);
+
+      assertMatch(
+        serialized,
+        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+      );
+      assertMatch(
+        serialized,
+        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+      );
+    },
+  );
+});

--- a/packages/autometrics/tests/callerInfo.test.ts
+++ b/packages/autometrics/tests/callerInfo.test.ts
@@ -21,11 +21,11 @@ Deno.test("Caller info test", async (t) => {
 
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/packages\/autometrics\/tests\/callerInfo.test.ts"\S*\} 1/gm,
       );
     },
   );
@@ -48,11 +48,11 @@ Deno.test("Caller info test", async (t) => {
 
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="bar"\S*caller=""\S*\} 1/gm,
+        /function_calls_total\{\S*function="bar"\S*caller_function=""\S*\} 1/gm,
       );
       assertMatch(
         serialized,
-        /function_calls_total\{\S*function="foo"\S*caller="bar"\S*\} 1/gm,
+        /function_calls_total\{\S*function="foo"\S*caller_function="bar"\S*caller_module="\/packages\/autometrics\/tests\/callerInfo.test.ts"\S*\} 1/gm,
       );
     },
   );

--- a/packages/autometrics/tests/temporality.test.ts
+++ b/packages/autometrics/tests/temporality.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "$std/assert/mod.ts";
 
-import { MetricData } from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+import { MetricData } from "$otel/sdk-metrics";
 import { autometrics } from "../mod.ts";
 import { COUNTER_NAME } from "../src/constants.ts";
 import {

--- a/packages/autometrics/tests/testUtils.ts
+++ b/packages/autometrics/tests/testUtils.ts
@@ -3,7 +3,7 @@ import {
   InMemoryMetricExporter,
   MetricReader,
   PeriodicExportingMetricReader,
-} from "npm:@opentelemetry/sdk-metrics@^1.17.0";
+} from "$otel/sdk-metrics";
 
 import { registerExporter } from "../mod.ts";
 import { PrometheusSerializer } from "../src/exporter-prometheus/PrometheusSerializer.ts";

--- a/packages/parcel-transformer-autometrics/package.json
+++ b/packages/parcel-transformer-autometrics/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "@parcel/core": "^2.10.0",
-    "@types/node": "^20.5.7"
+    "@types/node": "^18.6.5"
   }
 }

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -124,13 +124,7 @@ const packageJsonFields = {
 const dtsPlugin = dts();
 const swcPlugin = swc(
   defineRollupSwcOption({
-    jsc: {
-      target: "es2021",
-      transform: {
-        decoratorMetadata: true,
-        legacyDecorator: true,
-      },
-    },
+    jsc: { target: "es2021" },
     sourceMaps: true,
   }),
 );
@@ -251,7 +245,7 @@ async function generatePackageJson(outDir: string, packageInfo: PackageInfo) {
 }
 
 async function installPackage(outDir: string) {
-  console.log("- Running `yarn install`...");
+  console.log("- Running yarn install...");
 
   const yarn = new Deno.Command("yarn", {
     args: ["install"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "lib": ["ESNext"],
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "lib": ["ESNext"],
+    "lib": ["DOM", "ESNext"],
     "moduleResolution": "Bundler",
     "noEmit": true,
+    "paths": {
+      "$otel/*": ["./node_modules/@opentelemetry/*"]
+    },
     "strict": true
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,7 +866,6 @@ __metadata:
   resolution: "autometrics-monorepo@workspace:."
   dependencies:
     "@parcel/types": ^2.10.0
-    "@types/node": ^18.6.5
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@ __metadata:
   dependencies:
     "@parcel/core": ^2.10.0
     "@parcel/plugin": ^2.9.0
-    "@types/node": ^20.5.7
+    "@types/node": ^18.6.5
     typescript: ">=5.0.4"
   languageName: unknown
   linkType: soft
@@ -772,15 +772,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.5.7":
-  version: 20.8.6
-  resolution: "@types/node@npm:20.8.6"
-  dependencies:
-    undici-types: ~5.25.1
-  checksum: ccfb7ac482c5a96edeb239893c5c099f5257fcc2ed9ae62fefdfbc782b79e16dbc2af9a85b379665237bf759904b44ca2be68e75d239e0297882aad42f61905c
-  languageName: node
-  linkType: hard
-
 "abbrev@npm:^1.0.0":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
@@ -875,6 +866,7 @@ __metadata:
   resolution: "autometrics-monorepo@workspace:."
   dependencies:
     "@parcel/types": ^2.10.0
+    "@types/node": ^18.6.5
   languageName: unknown
   linkType: soft
 
@@ -2097,13 +2089,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~5.25.1":
-  version: 5.25.3
-  resolution: "undici-types@npm:5.25.3"
-  checksum: ec9d2cc36520cbd9fbe3b3b6c682a87fe5be214699e1f57d1e3d9a2cb5be422e62735f06e0067dc325fd3dd7404c697e4d479f9147dc8a804e049e29f357f2ff
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,7 @@ __metadata:
     "@opentelemetry/exporter-prometheus": ^0.43.0
     "@opentelemetry/sdk-metrics": ^1.17.0
     "@types/node": ^18.6.5
+    node-fetch-native: ^1.4.1
   languageName: unknown
   linkType: soft
 
@@ -196,6 +197,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/agent@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "@npmcli/agent@npm:2.2.0"
+  dependencies:
+    agent-base: ^7.1.0
+    http-proxy-agent: ^7.0.0
+    https-proxy-agent: ^7.0.1
+    lru-cache: ^10.0.1
+    socks-proxy-agent: ^8.0.1
+  checksum: 3b25312edbdfaa4089af28e2d423b6f19838b945e47765b0c8174c1395c79d43c3ad6d23cb364b43f59fd3acb02c93e3b493f72ddbe3dfea04c86843a7311fc4
+  languageName: node
+  linkType: hard
+
 "@npmcli/fs@npm:^3.1.0":
   version: 3.1.0
   resolution: "@npmcli/fs@npm:3.1.0"
@@ -310,7 +324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:1.17.1":
+"@opentelemetry/resources@npm:1.17.1, @opentelemetry/resources@npm:^1.17.0":
   version: 1.17.1
   resolution: "@opentelemetry/resources@npm:1.17.1"
   dependencies:
@@ -375,48 +389,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/cache@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/cache@npm:2.10.0"
+"@parcel/cache@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/cache@npm:2.10.1"
   dependencies:
-    "@parcel/fs": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/utils": 2.10.0
+    "@parcel/fs": 2.10.1
+    "@parcel/logger": 2.10.1
+    "@parcel/utils": 2.10.1
     lmdb: 2.8.5
   peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: 209d474abd5175309aaae06f4cbaebc7d1aadee260702e26268b7889d74132430c8ea52b1cd1829a98b60474856f671d26b99e698bd8a66a08d2c58d3e1ba264
+    "@parcel/core": ^2.10.1
+  checksum: 8a8be37a1e6cbf93e6684f3f06cbaaf97dd24160e4d47df3d6169de8cdbc45eeae7bfb70f3560b3e5d5c4712a41e61df8ed3b2e296ad2d9e0810eaed98ca69c1
   languageName: node
   linkType: hard
 
-"@parcel/codeframe@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/codeframe@npm:2.10.0"
+"@parcel/codeframe@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/codeframe@npm:2.10.1"
   dependencies:
     chalk: ^4.1.0
-  checksum: d87b17d3ce1c88652b3d66ee873e0578aadf90e718bcafaf16c7b39e0272cf61851530d9a3cda7482702afb9058a54f497b9e3cc706f2c36904ca0a6182ae2a1
+  checksum: 5d7ddf12b01436b29f7f87fa97c03f60c0dcf3028be53e9b84882f676b7d3cac73bf4178b6184180fdf3ce2cb62ef4bad5a5ae574a11b98d44f0064cf8afaf9a
   languageName: node
   linkType: hard
 
 "@parcel/core@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/core@npm:2.10.0"
+  version: 2.10.1
+  resolution: "@parcel/core@npm:2.10.1"
   dependencies:
     "@mischnic/json-sourcemap": ^0.1.0
-    "@parcel/cache": 2.10.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/events": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/graph": 3.0.0
-    "@parcel/logger": 2.10.0
-    "@parcel/package-manager": 2.10.0
-    "@parcel/plugin": 2.10.0
-    "@parcel/profiler": 2.10.0
-    "@parcel/rust": 2.10.0
+    "@parcel/cache": 2.10.1
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/events": 2.10.1
+    "@parcel/fs": 2.10.1
+    "@parcel/graph": 3.0.1
+    "@parcel/logger": 2.10.1
+    "@parcel/package-manager": 2.10.1
+    "@parcel/plugin": 2.10.1
+    "@parcel/profiler": 2.10.1
+    "@parcel/rust": 2.10.1
     "@parcel/source-map": ^2.1.1
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
-    "@parcel/workers": 2.10.0
+    "@parcel/types": 2.10.1
+    "@parcel/utils": 2.10.1
+    "@parcel/workers": 2.10.1
     abortcontroller-polyfill: ^1.1.9
     base-x: ^3.0.8
     browserslist: ^4.6.6
@@ -427,127 +441,127 @@ __metadata:
     msgpackr: ^1.5.4
     nullthrows: ^1.1.1
     semver: ^7.5.2
-  checksum: c59c2971ea6edc379fc166fefe60a6cbbbea0ee1c84120b7396c5b1a6bcfac2e0409647a007b38d6da27285b43d6582144f136a4b8f1652d01df589f16ffa6f0
+  checksum: d5c3155f8515973ee307d23a10ae5664eac6cc9017b630e93d221c5cbaf1bc332f9904b098f312107c26f5df611ba12ef3a2fd69217082b62373465bf3aa76f5
   languageName: node
   linkType: hard
 
-"@parcel/diagnostic@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/diagnostic@npm:2.10.0"
+"@parcel/diagnostic@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/diagnostic@npm:2.10.1"
   dependencies:
     "@mischnic/json-sourcemap": ^0.1.0
     nullthrows: ^1.1.1
-  checksum: 45c606ca52316433524060b4297b0d34a1b971a94bbd5e9e282aeaac3abb3d9f0839a97a7027fa653e7b3b77269962a0db5a960ffe345fac41c6235a14e15aa1
+  checksum: 37935f54ba6ee1efc98da8922844c16e6277c1bd05e04c903e3fcc7941803e471f699470a1ef58d774bfed0a7207dfc9718ce500c732fcaa64726b05f075e930
   languageName: node
   linkType: hard
 
-"@parcel/events@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/events@npm:2.10.0"
-  checksum: 1d21cd41862de2f21f2ab754b1d949fe17b062fbb8009a23d4d42f6836df7e1d37c2c8ca71304dce18d1168dedf0fcaa88c7c3eacc20611215b00700df0c9c73
+"@parcel/events@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/events@npm:2.10.1"
+  checksum: 60fed6bdfcb21aff106588bc824bace11cf9a709a62fb809ad02aa4723f9aebf4bb2a43373fb92197dadff7bd0a2710d4a225bd86f2a25378d370a9b09c8b861
   languageName: node
   linkType: hard
 
-"@parcel/fs@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/fs@npm:2.10.0"
+"@parcel/fs@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/fs@npm:2.10.1"
   dependencies:
-    "@parcel/rust": 2.10.0
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
+    "@parcel/rust": 2.10.1
+    "@parcel/types": 2.10.1
+    "@parcel/utils": 2.10.1
     "@parcel/watcher": ^2.0.7
-    "@parcel/workers": 2.10.0
+    "@parcel/workers": 2.10.1
   peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: 10faae481cf4cd0d0ae270c60e070a925f510ca7c93d208bd3c4159da4aff5e4e2e0ea61b58f3638557a469aa706037b3065b526ef207bbb4fdbe6048d04c082
+    "@parcel/core": ^2.10.1
+  checksum: 45323988ed45f2488ce1c8e94e740a2ba0a1bb56c5f5eb068f0014c88299e619a4298dc87d578320cfa004e21fe055b8155bbaa5c2d2406ae3a7490343705a4b
   languageName: node
   linkType: hard
 
-"@parcel/graph@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@parcel/graph@npm:3.0.0"
+"@parcel/graph@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@parcel/graph@npm:3.0.1"
   dependencies:
     nullthrows: ^1.1.1
-  checksum: 0a9d5017f6179d3a35a9f97060d24486efe045277e831550e2885b8afc05288a2a898da3ec1f920cb89c02cce8941642b4522e67194a773d50062dadb36f4567
+  checksum: 24469b16beeaab13b14fc9f7df8f897dce908dbf5b44791d1f7a438b212fd70caf6a57bb45f2bb8b981632249948304df1381cf9954b6167d7204401ff561290
   languageName: node
   linkType: hard
 
-"@parcel/logger@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/logger@npm:2.10.0"
+"@parcel/logger@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/logger@npm:2.10.1"
   dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/events": 2.10.0
-  checksum: 52d0b5331dd72778da4a2be798bb2b6d5e72ecb317cdad3a4c546807be1e30aa59b1cca6c57314438b30e62d89b578354098b939d72618ab0634c33d0261ee91
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/events": 2.10.1
+  checksum: 63b82d188898deb2116e980a2dade443100025cd3684d6b000c9420fa6217b0fa6189dab84862255cae065583a18a743b9bad5e842b1509fd0046cfd8203a0f0
   languageName: node
   linkType: hard
 
-"@parcel/markdown-ansi@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/markdown-ansi@npm:2.10.0"
+"@parcel/markdown-ansi@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/markdown-ansi@npm:2.10.1"
   dependencies:
     chalk: ^4.1.0
-  checksum: 35e2d07ec81e271144fc0f7b5f00913dce787e8a6f4a308eb59269fbc50d751cae939fedfd03e30b4aeef0c7f1210af2d1990a5551f1d39eeb80c977feb72b04
+  checksum: 2afd43d29ace0bac6683a4877423017c9e89f6afa9fcc68175a8a8959e0dab0da639c36b3dad830c388aa951172a5719e02cadf3260a0ac8053f87724242e300
   languageName: node
   linkType: hard
 
-"@parcel/node-resolver-core@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@parcel/node-resolver-core@npm:3.1.0"
+"@parcel/node-resolver-core@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@parcel/node-resolver-core@npm:3.1.1"
   dependencies:
     "@mischnic/json-sourcemap": ^0.1.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/rust": 2.10.0
-    "@parcel/utils": 2.10.0
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/fs": 2.10.1
+    "@parcel/rust": 2.10.1
+    "@parcel/utils": 2.10.1
     nullthrows: ^1.1.1
     semver: ^7.5.2
-  checksum: dcdd39bc6a044200fa734fbc58bba9b59c5ee2978c460b2734378adc7d47d724bdd98e942b0822305d0cfbd93bed1bb4ea37a6b8f8f7198e002890d9095f28ed
+  checksum: f8bbfe01adf90cdca7c6e2f491199f63b0069e4b9a780ab132432898d5a1a4ec3064e25d13ab0cb24555f8295d9379afdca78e77d578e9ab316a20bcda0e7c37
   languageName: node
   linkType: hard
 
-"@parcel/package-manager@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/package-manager@npm:2.10.0"
+"@parcel/package-manager@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/package-manager@npm:2.10.1"
   dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/node-resolver-core": 3.1.0
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
-    "@parcel/workers": 2.10.0
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/fs": 2.10.1
+    "@parcel/logger": 2.10.1
+    "@parcel/node-resolver-core": 3.1.1
+    "@parcel/types": 2.10.1
+    "@parcel/utils": 2.10.1
+    "@parcel/workers": 2.10.1
     semver: ^7.5.2
   peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: 7c4a95d9df4a819f2613839d30165e653182017a6d7c1b155ee46c46a921d086672daa70effba70cbc78379bb634176da254162b868b89c0e1b117079cc8c914
+    "@parcel/core": ^2.10.1
+  checksum: 00ad21e499194b7e34ce9bf191eb9c9a6656be8cca0a46edebb7b4fe3bd2e90bbbd85ede88cfcbd063caca20eaf82cb39a8a72eca7a01d9e59fd4b9c6eca3e84
   languageName: node
   linkType: hard
 
-"@parcel/plugin@npm:2.10.0, @parcel/plugin@npm:^2.9.0":
-  version: 2.10.0
-  resolution: "@parcel/plugin@npm:2.10.0"
+"@parcel/plugin@npm:2.10.1, @parcel/plugin@npm:^2.9.0":
+  version: 2.10.1
+  resolution: "@parcel/plugin@npm:2.10.1"
   dependencies:
-    "@parcel/types": 2.10.0
-  checksum: e13ba6e7e521078e7755ecdf906c0f1d8fe63efaec26bb66e2f0df22417e755bbced6dbbdea50698ad27944ed1a16944c143eb08c79e4118ea62bc7c60f62b5f
+    "@parcel/types": 2.10.1
+  checksum: c167858216a8f79013a6752fdfdb02ff543c36c340dd244fe0312fc5fd28388411a3e318ad1b6f7053d05cc88d1bb9fd267230d6a6f8cb43c2aca25c2b250aea
   languageName: node
   linkType: hard
 
-"@parcel/profiler@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/profiler@npm:2.10.0"
+"@parcel/profiler@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/profiler@npm:2.10.1"
   dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/events": 2.10.0
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/events": 2.10.1
     chrome-trace-event: ^1.0.2
-  checksum: 78d545edb76d72f962769df8964a3a19fe3d0b2b8c47a929eeafd9d71b3f00f2733428a649804057fce153a7fb71fa8bfdd25cc3102b32ea542b69af35f7ce4a
+  checksum: 6243db507366bc2883bd9d03f194e194a6baab2cc5f73b108c46b8ae9c8a131d4763be8732a2a571292b46dcd1b306d452e3562b6a731c3c07b99f0964d8917c
   languageName: node
   linkType: hard
 
-"@parcel/rust@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/rust@npm:2.10.0"
-  checksum: 466a78d27db445780593a6a5a1ce39406daabf3661b81aa8a714ba647d0e3b08532a23b86508a7e8b9cb95f8aa4f755c6e33148ba961f173283b96b72cc51ee6
+"@parcel/rust@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/rust@npm:2.10.1"
+  checksum: 4e87f5eb1d77c48a125943284b00d710bca6d9871c193aea0d46a4153cc3d64455ccf197f4de562f485291f15128960aafdb93f7ee56ba5c80cd07565a804a20
   languageName: node
   linkType: hard
 
@@ -560,34 +574,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/types@npm:2.10.0, @parcel/types@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/types@npm:2.10.0"
+"@parcel/types@npm:2.10.1, @parcel/types@npm:^2.10.0":
+  version: 2.10.1
+  resolution: "@parcel/types@npm:2.10.1"
   dependencies:
-    "@parcel/cache": 2.10.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/fs": 2.10.0
-    "@parcel/package-manager": 2.10.0
+    "@parcel/cache": 2.10.1
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/fs": 2.10.1
+    "@parcel/package-manager": 2.10.1
     "@parcel/source-map": ^2.1.1
-    "@parcel/workers": 2.10.0
+    "@parcel/workers": 2.10.1
     utility-types: ^3.10.0
-  checksum: 387aa079020ffec27f92d9496e0abd5e71e4b8e0ca1c9cf5b692737dd172d037302dd2c9d3cc32143813707050eb9de23e4e4eca32a65c402f6564a08da61e6f
+  checksum: 00c14c17cb4b55868044f1b07c2d67791d3726a390fa16f271a79efbe9d9b5cd3fd889361c7c1b8d74100f4119b305aacb5a05b8aba8bb84fd60ef4ac98a3854
   languageName: node
   linkType: hard
 
-"@parcel/utils@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/utils@npm:2.10.0"
+"@parcel/utils@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/utils@npm:2.10.1"
   dependencies:
-    "@parcel/codeframe": 2.10.0
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/markdown-ansi": 2.10.0
-    "@parcel/rust": 2.10.0
+    "@parcel/codeframe": 2.10.1
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/logger": 2.10.1
+    "@parcel/markdown-ansi": 2.10.1
+    "@parcel/rust": 2.10.1
     "@parcel/source-map": ^2.1.1
     chalk: ^4.1.0
     nullthrows: ^1.1.1
-  checksum: 9f4953ff9af730b59abbaa6f5f0c452a26848fc52d6f04a0facdc9ebfabb4434fd548ae38a7f882a4a5cd2db5a0b389b540fe7d2ffc6c286323062a764d2cc43
+  checksum: 60b357b03e54601fdc28a4358d2fbbbef98f183429a8afc3f58700f538c29352f33862b3d0560b007e7924b20ac8fd27de434050e519d38f9a836e72c88aef0b
   languageName: node
   linkType: hard
 
@@ -725,19 +739,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/workers@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@parcel/workers@npm:2.10.0"
+"@parcel/workers@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@parcel/workers@npm:2.10.1"
   dependencies:
-    "@parcel/diagnostic": 2.10.0
-    "@parcel/logger": 2.10.0
-    "@parcel/profiler": 2.10.0
-    "@parcel/types": 2.10.0
-    "@parcel/utils": 2.10.0
+    "@parcel/diagnostic": 2.10.1
+    "@parcel/logger": 2.10.1
+    "@parcel/profiler": 2.10.1
+    "@parcel/types": 2.10.1
+    "@parcel/utils": 2.10.1
     nullthrows: ^1.1.1
   peerDependencies:
-    "@parcel/core": ^2.10.0
-  checksum: e8b1701b53b2f3e913eee98e1e16def38a67d08b4835d25e1dd610505edc2f38c23729ec9b264ccd3c6ea3221814a314b657a3a3c41feebbdb01dcc34e69741c
+    "@parcel/core": ^2.10.1
+  checksum: fb58191d314b0b59d9997d2e107a4126776ead174bd96a30ccc78689e03a9a10c320ad41b9b0947f4ac85620e1382d5c3e159a8036bc34428f86a8242fd803dc
   languageName: node
   linkType: hard
 
@@ -748,24 +762,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^18.6.5":
-  version: 18.18.5
-  resolution: "@types/node@npm:18.18.5"
-  checksum: fc8c9b2bf226270cf9085a7dac76ce09dd7c3519ec9b687ee2b50385954ab3709c45ca82d002d1536e24286803cd194d7ab7008acebdcd6681b8b19d4277fa5c
+  version: 18.18.8
+  resolution: "@types/node@npm:18.18.8"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: d6a82bfc28bca8e4e32ffc9526798d1aea62f6993ea3a535cd3f47ac3f725a48efe3f484d68168dd154af0001c89935e4e1d77e7b1809c3824c6382bf99b86f6
   languageName: node
   linkType: hard
 
-"abbrev@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "abbrev@npm:1.1.1"
-  checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 0e994ad2aa6575f94670d8a2149afe94465de9cedaaaac364e7fb43a40c3691c980ff74899f682f4ca58fa96b4cbd7421a015d3a6defe43a442117d7821a2f36
   languageName: node
   linkType: hard
 
@@ -776,21 +785,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6, agent-base@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "agent-base@npm:7.1.0"
   dependencies:
-    debug: 4
-  checksum: f52b6872cc96fd5f622071b71ef200e01c7c4c454ee68bc9accca90c98cfb39f2810e3e9aa330435835eedc8c23f4f8a15267f67c6e245d2b33757575bdac49d
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.2.1":
-  version: 4.5.0
-  resolution: "agentkeepalive@npm:4.5.0"
-  dependencies:
-    humanize-ms: ^1.2.1
-  checksum: 13278cd5b125e51eddd5079f04d6fe0914ac1b8b91c1f3db2c1822f99ac1a7457869068997784342fe455d59daaff22e14fb7b8c3da4e741896e7e31faf92481
+    debug: ^4.3.4
+  checksum: f7828f991470a0cc22cb579c86a18cbae83d8a3cbed39992ab34fc7217c4d126017f1c74d0ab66be87f71455318a8ea3e757d6a37881b8d0f2a2c6aa55e5418f
   languageName: node
   linkType: hard
 
@@ -834,27 +834,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^1.0.3 || ^2.0.0":
-  version: 2.0.0
-  resolution: "aproba@npm:2.0.0"
-  checksum: 5615cadcfb45289eea63f8afd064ab656006361020e1735112e346593856f87435e02d8dcc7ff0d11928bc7d425f27bc7c2a84f6c0b35ab0ff659c814c138a24
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "are-we-there-yet@npm:3.0.1"
-  dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^3.6.0
-  checksum: 52590c24860fa7173bedeb69a4c05fb573473e860197f618b9a28432ee4379049336727ae3a1f9c4cb083114601c1140cee578376164d0e651217a9843f9fe83
-  languageName: node
-  linkType: hard
-
 "autometrics-monorepo@workspace:.":
   version: 0.0.0-use.local
   resolution: "autometrics-monorepo@workspace:."
   dependencies:
+    "@opentelemetry/api": ^1.6.0
+    "@opentelemetry/core": ^1.17.0
+    "@opentelemetry/exporter-metrics-otlp-http": ^0.43.0
+    "@opentelemetry/exporter-prometheus": ^0.43.0
+    "@opentelemetry/resources": ^1.17.0
+    "@opentelemetry/sdk-metrics": ^1.17.0
     "@parcel/types": ^2.10.0
     typescript: ^5.2.2
   languageName: unknown
@@ -873,16 +862,6 @@ __metadata:
   dependencies:
     safe-buffer: ^5.0.1
   checksum: 957101d6fd09e1903e846fd8f69fd7e5e3e50254383e61ab667c725866bec54e5ece5ba49ce385128ae48f9ec93a26567d1d5ebb91f4d56ef4a9cc0d5a5481e8
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
-  dependencies:
-    balanced-match: ^1.0.0
-    concat-map: 0.0.1
-  checksum: faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
   languageName: node
   linkType: hard
 
@@ -918,14 +897,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^17.0.0":
-  version: 17.1.4
-  resolution: "cacache@npm:17.1.4"
+"cacache@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "cacache@npm:18.0.0"
   dependencies:
     "@npmcli/fs": ^3.1.0
     fs-minipass: ^3.0.0
     glob: ^10.2.2
-    lru-cache: ^7.7.1
+    lru-cache: ^10.0.1
     minipass: ^7.0.3
     minipass-collect: ^1.0.2
     minipass-flush: ^1.0.5
@@ -934,14 +913,14 @@ __metadata:
     ssri: ^10.0.0
     tar: ^6.1.11
     unique-filename: ^3.0.0
-  checksum: b7751df756656954a51201335addced8f63fc53266fa56392c9f5ae83c8d27debffb4458ac2d168a744a4517ec3f2163af05c20097f93d17bdc2dc8a385e14a6
+  checksum: 2cd6bf15551abd4165acb3a4d1ef0593b3aa2fd6853ae16b5bb62199c2faecf27d36555a9545c0e07dd03347ec052e782923bdcece724a24611986aafb53e152
   languageName: node
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001541":
-  version: 1.0.30001549
-  resolution: "caniuse-lite@npm:1.0.30001549"
-  checksum: 7f2abeedc8cf8b92cc0613855d71b995ce436068c0bcdd798c5af7d297ccf9f52496b00181beda42d82d25079dd4b6e389c67486156d40d8854e5707a25cb054
+  version: 1.0.30001559
+  resolution: "caniuse-lite@npm:1.0.30001559"
+  checksum: 17c7af10244dca2c7ca41c884df19fc4c7313b9b03ed1f9b1f352bffbc871701f35431f766838f669ebe1f9d20627c0c6f2d760a0837538bd1d21de5833020f4
   languageName: node
   linkType: hard
 
@@ -999,29 +978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "color-support@npm:1.1.3"
-  bin:
-    color-support: bin.js
-  checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
-  languageName: node
-  linkType: hard
-
-"concat-map@npm:0.0.1":
-  version: 0.0.1
-  resolution: "concat-map@npm:0.0.1"
-  checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
-  languageName: node
-  linkType: hard
-
-"console-control-strings@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "console-control-strings@npm:1.1.0"
-  checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.0":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -1033,7 +989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.3":
+"debug@npm:4, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -1042,13 +998,6 @@ __metadata:
     supports-color:
       optional: true
   checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
-  languageName: node
-  linkType: hard
-
-"delegates@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "delegates@npm:1.0.0"
-  checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
   languageName: node
   linkType: hard
 
@@ -1090,9 +1039,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.535":
-  version: 1.4.556
-  resolution: "electron-to-chromium@npm:1.4.556"
-  checksum: 8c9aa48776d80c23d8709dcd4342f1b18ca5b63bdb233fb6913f0db7b382d69afa84d5f08ead84bde6378a6a7ab3d1127f7cb6f4d0642fa625e96de6559dc1d7
+  version: 1.4.571
+  resolution: "electron-to-chromium@npm:1.4.571"
+  checksum: 4e0900ef08e941be51e727fb51ef9375157806de2d6888ec52bdea933a8cd672ad8b68746c9f84d396780b75140fb279e06c5c197a865794436c6c9271fddaa2
   languageName: node
   linkType: hard
 
@@ -1184,30 +1133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs.realpath@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fs.realpath@npm:1.0.0"
-  checksum: 99ddea01a7e75aa276c250a04eedeffe5662bce66c65c07164ad6264f9de18fb21be9433ead460e54cff20e31721c811f4fb5d70591799df5f85dce6d6746fd0
-  languageName: node
-  linkType: hard
-
-"gauge@npm:^4.0.3":
-  version: 4.0.4
-  resolution: "gauge@npm:4.0.4"
-  dependencies:
-    aproba: ^1.0.3 || ^2.0.0
-    color-support: ^1.1.3
-    console-control-strings: ^1.1.0
-    has-unicode: ^2.0.1
-    signal-exit: ^3.0.7
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-    wide-align: ^1.1.5
-  checksum: 788b6bfe52f1dd8e263cda800c26ac0ca2ff6de0b6eee2fe0d9e3abf15e149b651bd27bf5226be10e6e3edb5c4e5d5985a5a1a98137e7a892f75eff76467ad2d
-  languageName: node
-  linkType: hard
-
-"glob@npm:^10.2.2":
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -1219,20 +1145,6 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 4f2fe2511e157b5a3f525a54092169a5f92405f24d2aed3142f4411df328baca13059f4182f1db1bf933e2c69c0bd89e57ae87edd8950cba8c7ccbe84f721cf3
-  languageName: node
-  linkType: hard
-
-"glob@npm:^7.1.3, glob@npm:^7.1.4":
-  version: 7.2.3
-  resolution: "glob@npm:7.2.3"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.1.1
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
   languageName: node
   linkType: hard
 
@@ -1250,13 +1162,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "has-unicode@npm:2.0.1"
-  checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
-  languageName: node
-  linkType: hard
-
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -1264,33 +1169,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0"
+"http-proxy-agent@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "http-proxy-agent@npm:7.0.0"
   dependencies:
-    "@tootallnate/once": 2
-    agent-base: 6
-    debug: 4
-  checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
+    agent-base: ^7.1.0
+    debug: ^4.3.4
+  checksum: 48d4fac997917e15f45094852b63b62a46d0c8a4f0b9c6c23ca26d27b8df8d178bed88389e604745e748bd9a01f5023e25093722777f0593c3f052009ff438b6
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
+"https-proxy-agent@npm:^7.0.1":
+  version: 7.0.2
+  resolution: "https-proxy-agent@npm:7.0.2"
   dependencies:
-    agent-base: 6
+    agent-base: ^7.0.2
     debug: 4
-  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
-  languageName: node
-  linkType: hard
-
-"humanize-ms@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "humanize-ms@npm:1.2.1"
-  dependencies:
-    ms: ^2.0.0
-  checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  checksum: 088969a0dd476ea7a0ed0a2cf1283013682b08f874c3bc6696c83fa061d2c157d29ef0ad3eb70a2046010bb7665573b2388d10fdcb3e410a66995e5248444292
   languageName: node
   linkType: hard
 
@@ -1314,23 +1209,6 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: 824cfb9929d031dabf059bebfe08cf3137365e112019086ed3dcff6a0a7b698cb80cf67ccccde0e25b9e2d7527aa6cc1fed1ac490c752162496caba3e6699612
-  languageName: node
-  linkType: hard
-
-"inflight@npm:^1.0.4":
-  version: 1.0.6
-  resolution: "inflight@npm:1.0.6"
-  dependencies:
-    once: ^1.3.0
-    wrappy: 1
-  checksum: f4f76aa072ce19fae87ce1ef7d221e709afb59d445e05d47fba710e85470923a75de35bfae47da6de1b18afc3ce83d70facf44cfb0aff89f0a3f45c0a0244dfd
-  languageName: node
-  linkType: hard
-
-"inherits@npm:2, inherits@npm:^2.0.3":
-  version: 2.0.4
-  resolution: "inherits@npm:2.0.4"
-  checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
   languageName: node
   linkType: hard
 
@@ -1382,6 +1260,13 @@ __metadata:
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: 26bf6c5480dda5161c820c5b5c751ae1e766c587b1f951ea3fcfc973bafb7831ae5b54a31a69bd670220e42e99ec154475025a468eae58ea262f813fdc8d1c62
+  languageName: node
+  linkType: hard
+
+"isexe@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "isexe@npm:3.1.1"
+  checksum: 7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
   languageName: node
   linkType: hard
 
@@ -1449,6 +1334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.0.1, lru-cache@npm:^9.1.1 || ^10.0.0":
+  version: 10.0.1
+  resolution: "lru-cache@npm:10.0.1"
+  checksum: 06f8d0e1ceabd76bb6f644a26dbb0b4c471b79c7b514c13c6856113879b3bf369eb7b497dad4ff2b7e2636db202412394865b33c332100876d838ad1372f0181
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^6.0.0":
   version: 6.0.0
   resolution: "lru-cache@npm:6.0.0"
@@ -1458,40 +1350,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.7.1":
-  version: 7.18.3
-  resolution: "lru-cache@npm:7.18.3"
-  checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^9.1.1 || ^10.0.0":
-  version: 10.0.1
-  resolution: "lru-cache@npm:10.0.1"
-  checksum: 06f8d0e1ceabd76bb6f644a26dbb0b4c471b79c7b514c13c6856113879b3bf369eb7b497dad4ff2b7e2636db202412394865b33c332100876d838ad1372f0181
-  languageName: node
-  linkType: hard
-
-"make-fetch-happen@npm:^11.0.3":
-  version: 11.1.1
-  resolution: "make-fetch-happen@npm:11.1.1"
+"make-fetch-happen@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "make-fetch-happen@npm:13.0.0"
   dependencies:
-    agentkeepalive: ^4.2.1
-    cacache: ^17.0.0
+    "@npmcli/agent": ^2.0.0
+    cacache: ^18.0.0
     http-cache-semantics: ^4.1.1
-    http-proxy-agent: ^5.0.0
-    https-proxy-agent: ^5.0.0
     is-lambda: ^1.0.1
-    lru-cache: ^7.7.1
-    minipass: ^5.0.0
+    minipass: ^7.0.2
     minipass-fetch: ^3.0.0
     minipass-flush: ^1.0.5
     minipass-pipeline: ^1.2.4
     negotiator: ^0.6.3
     promise-retry: ^2.0.1
-    socks-proxy-agent: ^7.0.0
     ssri: ^10.0.0
-  checksum: 7268bf274a0f6dcf0343829489a4506603ff34bd0649c12058753900b0eb29191dce5dba12680719a5d0a983d3e57810f594a12f3c18494e93a1fbc6348a4540
+  checksum: 7c7a6d381ce919dd83af398b66459a10e2fe8f4504f340d1d090d3fa3d1b0c93750220e1d898114c64467223504bd258612ba83efbc16f31b075cd56de24b4af
   languageName: node
   linkType: hard
 
@@ -1502,15 +1376,6 @@ __metadata:
     braces: ^3.0.2
     picomatch: ^2.3.1
   checksum: 02a17b671c06e8fefeeb6ef996119c1e597c942e632a21ef589154f23898c9c6a9858526246abb14f8bca6e77734aa9dcf65476fca47cedfb80d9577d52843fc
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
   languageName: node
   linkType: hard
 
@@ -1590,7 +1455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.3":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3":
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
@@ -1620,13 +1485,6 @@ __metadata:
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
-"ms@npm:^2.0.0":
-  version: 2.1.3
-  resolution: "ms@npm:2.1.3"
-  checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
   languageName: node
   linkType: hard
 
@@ -1698,6 +1556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch-native@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "node-fetch-native@npm:1.4.1"
+  checksum: 339001ad3235a09b195198df8be71b591eec4064a2fcfb7f54b9f0716f6ccb3bda5828e1746f809a6d2edb062a0330e5798f408396c33b3b88339c73d6e9575d
+  languageName: node
+  linkType: hard
+
 "node-gyp-build-optional-packages@npm:5.0.7":
   version: 5.0.7
   resolution: "node-gyp-build-optional-packages@npm:5.0.7"
@@ -1723,23 +1588,22 @@ __metadata:
   linkType: hard
 
 "node-gyp@npm:latest":
-  version: 9.4.0
-  resolution: "node-gyp@npm:9.4.0"
+  version: 10.0.0
+  resolution: "node-gyp@npm:10.0.0"
   dependencies:
     env-paths: ^2.2.0
     exponential-backoff: ^3.1.1
-    glob: ^7.1.4
+    glob: ^10.3.10
     graceful-fs: ^4.2.6
-    make-fetch-happen: ^11.0.3
-    nopt: ^6.0.0
-    npmlog: ^6.0.0
-    rimraf: ^3.0.2
+    make-fetch-happen: ^13.0.0
+    nopt: ^7.0.0
+    proc-log: ^3.0.0
     semver: ^7.3.5
     tar: ^6.1.2
-    which: ^2.0.2
+    which: ^4.0.0
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 78b404e2e0639d64e145845f7f5a3cb20c0520cdaf6dda2f6e025e9b644077202ea7de1232396ba5bde3fee84cdc79604feebe6ba3ec84d464c85d407bb5da99
+  checksum: 65fa5d9f8ef03fa22c5f2d34da23435a63d3743400ca941a4394eb943cf340796456697a7797af1451606dbbeecb663be9328995dadc0b99e58dd583dc3a7a0f
   languageName: node
   linkType: hard
 
@@ -1750,26 +1614,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nopt@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "nopt@npm:6.0.0"
+"nopt@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "nopt@npm:7.2.0"
   dependencies:
-    abbrev: ^1.0.0
+    abbrev: ^2.0.0
   bin:
     nopt: bin/nopt.js
-  checksum: 82149371f8be0c4b9ec2f863cc6509a7fd0fa729929c009f3a58e4eb0c9e4cae9920e8f1f8eb46e7d032fec8fb01bede7f0f41a67eb3553b7b8e14fa53de1dac
-  languageName: node
-  linkType: hard
-
-"npmlog@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "npmlog@npm:6.0.2"
-  dependencies:
-    are-we-there-yet: ^3.0.0
-    console-control-strings: ^1.1.0
-    gauge: ^4.0.3
-    set-blocking: ^2.0.0
-  checksum: ae238cd264a1c3f22091cdd9e2b106f684297d3c184f1146984ecbe18aaa86343953f26b9520dedd1b1372bc0316905b736c1932d778dbeb1fcf5a1001390e2a
+  checksum: a9c0f57fb8cb9cc82ae47192ca2b7ef00e199b9480eed202482c962d61b59a7fbe7541920b2a5839a97b42ee39e288c0aed770e38057a608d7f579389dfde410
   languageName: node
   linkType: hard
 
@@ -1777,15 +1629,6 @@ __metadata:
   version: 1.1.1
   resolution: "nullthrows@npm:1.1.1"
   checksum: 10806b92121253eb1b08ecf707d92480f5331ba8ae5b23fa3eb0548ad24196eb797ed47606153006568a5733ea9e528a3579f21421f7828e09e7756f4bdd386f
-  languageName: node
-  linkType: hard
-
-"once@npm:^1.3.0":
-  version: 1.4.0
-  resolution: "once@npm:1.4.0"
-  dependencies:
-    wrappy: 1
-  checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
   languageName: node
   linkType: hard
 
@@ -1802,13 +1645,6 @@ __metadata:
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
-  languageName: node
-  linkType: hard
-
-"path-is-absolute@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "path-is-absolute@npm:1.0.1"
-  checksum: 060840f92cf8effa293bcc1bea81281bd7d363731d214cbe5c227df207c34cd727430f70c6037b5159c8a870b9157cba65e775446b0ab06fd5ecc7e54615a3b8
   languageName: node
   linkType: hard
 
@@ -1843,6 +1679,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proc-log@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "proc-log@npm:3.0.0"
+  checksum: 02b64e1b3919e63df06f836b98d3af002b5cd92655cab18b5746e37374bfb73e03b84fe305454614b34c25b485cc687a9eebdccf0242cda8fda2475dd2c97e02
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -1853,17 +1696,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.6.0":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: bdcbe6c22e846b6af075e32cf8f4751c2576238c5043169a1c221c92ee2878458a816a4ea33f4c67623c0b6827c8a400409bfb3cf0bf3381392d0b1dfb52ac8d
-  languageName: node
-  linkType: hard
-
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -1871,18 +1703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "rimraf@npm:3.0.2"
-  dependencies:
-    glob: ^7.1.3
-  bin:
-    rimraf: bin.js
-  checksum: 87f4164e396f0171b0a3386cc1877a817f572148ee13a7e113b238e48e8a9f2f31d009a92ec38a591ff1567d9662c6b67fd8818a2dbbaed74bc26a87a2a4a9a0
-  languageName: node
-  linkType: hard
-
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:^5.0.1":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -1907,13 +1728,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "set-blocking@npm:2.0.0"
-  checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -1927,13 +1741,6 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
-  languageName: node
-  linkType: hard
-
-"signal-exit@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "signal-exit@npm:3.0.7"
-  checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
   languageName: node
   linkType: hard
 
@@ -1951,18 +1758,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "socks-proxy-agent@npm:7.0.0"
+"socks-proxy-agent@npm:^8.0.1":
+  version: 8.0.2
+  resolution: "socks-proxy-agent@npm:8.0.2"
   dependencies:
-    agent-base: ^6.0.2
-    debug: ^4.3.3
-    socks: ^2.6.2
-  checksum: 720554370154cbc979e2e9ce6a6ec6ced205d02757d8f5d93fe95adae454fc187a5cbfc6b022afab850a5ce9b4c7d73e0f98e381879cf45f66317a4895953846
+    agent-base: ^7.0.2
+    debug: ^4.3.4
+    socks: ^2.7.1
+  checksum: 4fb165df08f1f380881dcd887b3cdfdc1aba3797c76c1e9f51d29048be6e494c5b06d68e7aea2e23df4572428f27a3ec22b3d7c75c570c5346507433899a4b6d
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.2":
+"socks@npm:^2.7.1":
   version: 2.7.1
   resolution: "socks@npm:2.7.1"
   dependencies:
@@ -1981,7 +1788,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -2000,15 +1807,6 @@ __metadata:
     emoji-regex: ^9.2.2
     strip-ansi: ^7.0.1
   checksum: 7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
-  languageName: node
-  linkType: hard
-
-"string_decoder@npm:^1.1.1":
-  version: 1.3.0
-  resolution: "string_decoder@npm:1.3.0"
-  dependencies:
-    safe-buffer: ~5.2.0
-  checksum: 8417646695a66e73aefc4420eb3b84cc9ffd89572861fe004e6aeb13c7bc00e2f616247505d2dbbef24247c372f70268f594af7126f43548565c68c117bdeb56
   languageName: node
   linkType: hard
 
@@ -2082,6 +1880,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^3.0.0":
   version: 3.0.0
   resolution: "unique-filename@npm:3.0.0"
@@ -2114,13 +1919,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "util-deprecate@npm:1.0.2"
-  checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
 "utility-types@npm:^3.10.0":
   version: 3.10.0
   resolution: "utility-types@npm:3.10.0"
@@ -2135,7 +1933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1, which@npm:^2.0.2":
+"which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
@@ -2146,12 +1944,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "wide-align@npm:1.1.5"
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
   dependencies:
-    string-width: ^1.0.2 || 2 || 3 || 4
-  checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
+    isexe: ^3.1.1
+  bin:
+    node-which: bin/which.js
+  checksum: f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
   languageName: node
   linkType: hard
 
@@ -2174,13 +1974,6 @@ __metadata:
     string-width: ^5.0.1
     strip-ansi: ^7.0.1
   checksum: 371733296dc2d616900ce15a0049dca0ef67597d6394c57347ba334393599e800bab03c41d4d45221b6bc967b8c453ec3ae4749eff3894202d16800fdfe0e238
-  languageName: node
-  linkType: hard
-
-"wrappy@npm:1":
-  version: 1.0.2
-  resolution: "wrappy@npm:1.0.2"
-  checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,6 +866,7 @@ __metadata:
   resolution: "autometrics-monorepo@workspace:."
   dependencies:
     "@parcel/types": ^2.10.0
+    typescript: ^5.2.2
   languageName: unknown
   linkType: soft
 
@@ -2071,7 +2072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=5.0.4, typescript@npm:^5.0.4":
+"typescript@npm:>=5.0.4, typescript@npm:^5.0.4, typescript@npm:^5.2.2":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
   bin:
@@ -2081,7 +2082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@>=5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@>=5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.2.2
   resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:


### PR DESCRIPTION
Okay, this was a bit more involved again than I'd hoped. But! We have first-class web builds now... at least in the NPM packages. What this PR does:

* Replaces `dnt` with `rollup`. While `dnt` was a great starting point, and is certainly easier out-of-the-box, we didn't really use their shimming abilities anyway and `rollup` gives us the flexibility to more easily build dedicated web builds. Also, the packages are now smaller, since everything gets bundled into single-file builds.
* Introduced `$otel/*` imports. This makes it a lot easier to upgrade the OpenTelemetry libs, since the version numbers aren't hardcoded all over the place anymore.
* @keturiosakys's fix for getting caller info in line with the Autometrics spec are also included, as are tests for the caller info.
* Fixes the issues we had with `AsyncLocalStorage`.
* `react-app-experimental` is now also included in the builds and type-checking.
* `just clean` is a bit more thorough, by also removing `node_modules` and `.yarn` where applicable.

Resolves #89, #100, #133 and #134.