### PR TITLE
Use dots for OTLP labels

### DIFF
--- a/packages/autometrics/src/constants.ts
+++ b/packages/autometrics/src/constants.ts
@@ -8,21 +8,21 @@ export const GAUGE_NAME = "function.calls.concurrent" as const;
 export const BUILD_INFO_NAME = "build_info" as const;
 
 // Labels
-export const AUTOMETRICS_VERSION_LABEL = "autometrics_version" as const;
+export const AUTOMETRICS_VERSION_LABEL = "autometrics.version" as const;
 export const BRANCH_LABEL = "branch" as const;
-export const CALLER_FUNCTION_LABEL = "caller_function" as const;
-export const CALLER_MODULE_LABEL = "caller_module" as const;
+export const CALLER_FUNCTION_LABEL = "caller.function" as const;
+export const CALLER_MODULE_LABEL = "caller.module" as const;
 export const COMMIT_LABEL = "commit" as const;
 export const FUNCTION_LABEL = "function" as const;
 export const MODULE_LABEL = "module" as const;
-export const OBJECTIVE_NAME_LABEL = "objective_name" as const;
-export const OBJECTIVE_PERCENTILE_LABEL = "objective_percentile" as const;
+export const OBJECTIVE_NAME_LABEL = "objective.name" as const;
+export const OBJECTIVE_PERCENTILE_LABEL = "objective.percentile" as const;
 export const OBJECTIVE_LATENCY_THRESHOLD_LABEL =
-  "objective_latency_threshold" as const;
-export const REPOSITORY_URL_LABEL = "repository_url" as const;
-export const REPOSITORY_PROVIDER_LABEL = "repository_provider" as const;
+  "objective.latency_threshold" as const;
+export const REPOSITORY_URL_LABEL = "repository.url" as const;
+export const REPOSITORY_PROVIDER_LABEL = "repository.provider" as const;
 export const RESULT_LABEL = "result" as const;
-export const SERVICE_NAME_LABEL = "service_name" as const;
+export const SERVICE_NAME_LABEL = "service.name" as const;
 export const VERSION_LABEL = "version" as const;
 
 // Descriptions

--- a/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
+++ b/packages/autometrics/tests/__snapshots__/otlpHttpExporter.test.ts.snap
@@ -2,12 +2,12 @@ export const snapshot = {};
 
 snapshot[`OTLP/HTTP exporter 1`] = `
 {
-  caller_function: "",
-  caller_module: "",
+  "caller.function": "",
+  "caller.module": "",
+  "objective.name": "",
+  "objective.percentile": "",
   function: "foo",
   module: "/packages/autometrics/tests/otlpHttpExporter.test.ts",
-  objective_name: "",
-  objective_percentile: "",
   result: "ok",
 }
 `;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "lib": ["DOM", "ESNext"],
+    "module": "ES2022",
     "moduleResolution": "Bundler",
     "noEmit": true,
     "paths": {


### PR DESCRIPTION
This merely changes all the label constants to use dots instead of underscores, so they get submitted to OTLP endpoints according to the 1.0 spec.

I didn't have to change anything for the Prometheus exporters, because it appears the libraries do the translation back to underscores for us (and we have test coverage for it).

Implements AM-46.