### PR TITLE
Don't test Parcel and TS plugins before releasing lib

### DIFF
--- a/.github/workflows/publish_lib_to_npm.yml
+++ b/.github/workflows/publish_lib_to_npm.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Perform type-checking
         run: just type-check-all
 
-      - name: Run all tests
-        run: just test-all
+      - name: Run tests
+        run: just test && just test-examples
 
       - name: Publish
         run: just release-lib


### PR DESCRIPTION
We haven't built them, so it breaks because of that. Alternatively, we could build and test them too, but since they're independent I don't think it'll add much (except minutes spent on the CI).