### PR TITLE
Update CHANGELOG + release announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,70 @@
 # Changelog
 
-## [unreleased]
+## [v1.0.0]
 
-- **Breaking change:** Split the exporters into separate packages. Users will
-  need to explicitly choose an exporter and call its `init()` function.
-- (_experimental_) Push metrics to gateway "eagerly" when pushInterval is set to 0
-- Log error when fetch is not defined in push context
+This release features full compliance with the
+[Autometrics v1.0.0 specification](https://github.com/autometrics-dev/autometrics-shared/blob/main/specs/autometrics_v1.0.0.md)
+as well as first-class [Deno](https://deno.com/) support. Also, our decorators
+have been updated to match the
+[Stage 3 ECMAScript decorators proposal](https://github.com/tc39/proposal-decorators).
+
+### Changed
+
+- **BREAKING:** Labels are submitted with dots instead of underscores when
+  exported through OTLP. This should not affect exports to Prometheus.
+- **BREAKING:** The `@Autometrics` decorator is now compliant with the
+  [Stage 3 ECMAScript decorators proposal](https://github.com/tc39/proposal-decorators).
+  For the legacy TypeScript decorators, please use `@AutometricsLegacy` instead.
+- **BREAKING:** *Autometrics 1.0:* `caller.function` and `caller.module` have
+  been changed to match the specification.
+- Deno has become a first-class supported platform.
+
+### Added
+
+- *Autometrics 1.0:* Added support for the `service.name` label.
+- *Autometrics 1.0:* Added support for the `repository.url` and
+  `repository.provider` labels.
+- *Autometrics 1.0:* Added support for excluding individual methods from the
+  class decorator, using `@Autometrics({ skip: true })`. This also works with
+  the legacy decorator.
+- *Autometrics 1.0:* Users should see a warning in their console if they've
+  configured an invalid objective name.
+
+### Fixed
+
+- Fixed `this` handling in the wrappers and decorators.
+- Fixed using the `autometrics` package with web bundlers such as Parcel and
+  WebPack.
+- Fixed an issue where caller information sometimes wasn't submitted.
+
+## [v0.7.0]
+
+### Changed
+
+**BREAKING:** v0.7 is a big change to how the Autometrics library works in
+JavaScript. The core library interface of wrappers and decorators remains the
+same and will collect the metrics as previously, however it will not export
+them. For that purpose exporters are now separate to the library itself allowing
+the user more control as to how they want to set up the metrics collection: as a
+pull endpoint for Prometheus, push gateway, OpenTelemetry collector or something
+else.
+
+- Users need to explicitly choose an exporter and call its `init()` function.
+- *Experimental:* Eagerly push metrics when `pushInterval` is set to 0.
+
+### Added
+
+- Support Bun runtime in the core library.
+- Warn on a potentially incorrect HTTP OTLP endpoint.
+- *Experimental:* Initial Gravel Gateway Support.
+
+### Fixed
+
+- Clear timer on handover.
+- Log error when fetch is not defined in push context.
+- Fix default Prometheus exporter port.
+- Various smaller bugfixes.
+- Updated all our examples.
 
 ## [v0.6.0] - @autometrics/autometrics - 2023-07-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,10 +128,11 @@ you want to publish you will need to create a separate release.
 1. Ensure that the version number in the root `package.json` is up to date
 2. Run `just build-all` to make sure lock files in the examples are updated
    correctly.
-3. Make sure that all tests have successfully passed in the latest commit on
+3. Update the `CHANGELOG.md`.
+4. Make sure that all tests have successfully passed in the latest commit on
    `main` (the CI will run one more time before publishing it to NPM)
-4. Create a release on GitHub along with a respective tag for each package:
+5. Create a release on GitHub along with a respective tag for each package:
    - `lib/` (main autometrics library) → tag: `lib-*` (e.g.: `lib-v0.7`)
    - `typescript-plugin/` → tag: `typescript-plugin-*`
    - `parcel-transformer-autometrics/` → tag: `parcel-transformer-*`
-5. When the release is published, the relevant GitHub workflow will kick off.
+6. When the release is published, the relevant GitHub workflow will kick off.


### PR DESCRIPTION
In addition to the `CHANGELOG.md`, please review the release announcement as well:

***

This release features full compliance with the [Autometrics v1.0.0 specification](https://github.com/autometrics-dev/autometrics-shared/blob/main/specs/autometrics_v1.0.0.md) as well as first-class [Deno](https://deno.com/) support. Also, our decorators have been updated to match the [Stage 3 ECMAScript decorators proposal](https://github.com/tc39/proposal-decorators).

## Autometrics 1.0.0

In order to match the full Autometrics specification, we implemented the following features and changes:

* Decorators now have support for skipping individual methods when decorating a class. Just decorate the method you wish to exclude with `@Autometrics({ skip: true })`.
* We added support for the `service.name` label.  The service name is automatically detected based on the `AUTOMETRICS_SERVICE_NAME` or `OTEL_SERVICE_NAME` environment variables (in order of significance). If neither environment variable is set, Autometrics-ts attempts to determine the service name based on the package name defined in `package.json`.
* We also added support for the `repository.url` and `repository.provider` labels. These labels can be used to create links from Autometrics function metrics directly to your source code. We attempt to auto-detect these labels based on your Git configuration, but you can configure them explicitly using the `AUTOMETRICS_REPOSITORY_URL` and `AUTOMETRICS_REPOSITORY_PROVIDER` environment variables.
* When submitting metrics using OTLP, we now use dots in label names instead of underscores. For instance, `function.name` instead of `function_name`. When used with Prometheus, labels should still be exported using underscores.
* Users should see a warning in their console if they've configured an invalid objective name.

Note that all labels such as `service.name` and `repository.url`/`repository.provider` are also configurable in the `init()` function, in addition to using environment variables.

## Deno support

We already offered experimental Deno support before, but with this release we've taken things one step further: We've migrated the Autometrics-ts core library to be Deno-first! This means we use Deno for our internal development and the Deno library is a first-class citizen. Most of our core unit tests also run in Deno now.

We also publish Deno releases straight to https://deno.land/x/autometrics now. (Please note there is still a slightly awkward `lib-` prefix in the version specifiers, which we hope to resolve in the future.)

## Improved web compatibility

Thanks to the plumbing we did for moving to a Deno-first approach (shoutout [dnt](https://github.com/denoland/dnt) and [rollup](https://rollupjs.org/)!), we have also been able to improve our compatibility with web bundlers. We now generate two versions of our NPM packages, one for Node.js users and one for web users. They're both bundled within the same package, so this should be fully transparent to our users.

## Modern decorators

Previous versions of Autometrics-ts only supported the TypeScript-specific legacy decorators. We still support those as well, but they've been renamed to `@AutometricsLegacy`. The new `@Autometrics` decorators are fully compliant with the [ECMAScript proposal](https://github.com/tc39/proposal-decorators).

The updated feature set, such as the new `@Autometrics({ skip: true })` option, is supported by both our modern and legacy decorators alike.

## Detailed CHANGELOG

Here is a more detailed list of changes:

### Changed

- **BREAKING:** Labels are submitted with dots instead of underscores when
  exported through OTLP. This should not affect exports to Prometheus.
- **BREAKING:** The `@Autometrics` decorator is now compliant with the
  [Stage 3 ECMAScript decorators proposal](https://github.com/tc39/proposal-decorators).
  For the legacy TypeScript decorators, please use `@AutometricsLegacy` instead.
- **BREAKING:** *Autometrics 1.0:* `caller.function` and `caller.module` have
  been changed to match the specification.
- Deno has become a first-class supported platform.

### Added

- *Autometrics 1.0:* Added support for the `service.name` label.
- *Autometrics 1.0:* Added support for the `repository.url` and
  `repository.provider` labels.
- *Autometrics 1.0:* Added support for excluding individual methods from the
  class decorator, using `@Autometrics({ skip: true })`. This also works with
  the legacy decorator.
- *Autometrics 1.0:* Users should see a warning in their console if they've
  configured an invalid objective name.

### Fixed

- Fixed `this` handling in the wrappers and decorators.
- Fixed using the `autometrics` package with web bundlers such as Parcel and
  WebPack.
- Fixed an issue where caller information sometimes wasn't submitted.