### PR TITLE
Change publish command

### DIFF
--- a/justfile
+++ b/justfile
@@ -101,6 +101,6 @@ release-lib:
     set -euxo pipefail
     for package in {{lib_packages}}; do
         pushd "dist/$package"
-        yarn npm publish
+        npm publish
         popd
     done


### PR DESCRIPTION
I *think* we used plain `npm publish` before, so it is probably configured for that. Anyway, we'll test it with the next release, since I don't want to create a new tag, or we'll also publish the Deno version multiple times.