### PR TITLE
fix an infinite loop which happens when autometrics is initialized in a node service without a git repository

### DIFF
--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -112,6 +112,15 @@ export function getALSInstance() {
   }>();
 }
 
+/**
+ * Returns a boolean indicating whether a given path is the file-system root or not.
+ *
+ * @internal
+ */
+export function isRootPath(pathToCheck: str): string {
+  return pathToCheck == path.parse(getCwd()).root;
+}
+
 function detectPackageName(): string | undefined {
   try {
     const gitConfig = readClosest("package.json");
@@ -139,8 +148,11 @@ function readClosest(path: string): Uint8Array {
     try {
       return readFileSync(join(basePath, path));
     } catch {
+      // Break once we've tried the file-system root
+      if (isRootPath(basePath)) {
+        break;
+      }
       basePath = dirname(basePath);
-      break;
     }
   }
 

--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -140,6 +140,7 @@ function readClosest(path: string): Uint8Array {
       return readFileSync(join(basePath, path));
     } catch {
       basePath = dirname(basePath);
+      break;
     }
   }
 

--- a/packages/autometrics/src/platform.node.ts
+++ b/packages/autometrics/src/platform.node.ts
@@ -4,7 +4,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, parse } from "node:path";
 
 import { AUTOMETRICS_DEFAULT_SERVICE_NAME } from "./constants.ts";
 import { getGitRepositoryUrl, getPackageStringField } from "./platformUtils.ts";
@@ -117,8 +117,8 @@ export function getALSInstance() {
  *
  * @internal
  */
-export function isRootPath(pathToCheck: str): string {
-  return pathToCheck == path.parse(getCwd()).root;
+export function isRootPath(pathToCheck: string): boolean {
+  return pathToCheck == parse(getCwd()).root;
 }
 
 function detectPackageName(): string | undefined {


### PR DESCRIPTION
after instrumenting my node / ts server with autometrics, things seemed to be working just fine locally.

unfortunately when i deployed to my dev environment (kubernetes cluster) i saw my service spike in cpu utilization and the event loop would hang causing all requests to time out.

this made it difficult to debug since i was unable to reproduce locally initially. i found that i could reproduce this behavior if i built the docker image and ran the container locally. from there i was able to run node with profiling flags to get the v8 log output. this pointed me to the `readFileSync` call inside the `readClosest` function and the issue became clear. there is an unhandled case on the node platform that will result in an infinite while loop if no git repository is initialized (as is the case in a container).

this fixes that, but i'm uncertain if the other differences found between the [node](https://github.com/autometrics-dev/autometrics-ts/blob/06ff7739ccd82f2a1d382f3b0d62c906ea72956a/packages/autometrics/src/platform.node.ts#L136-L144) and [deno](https://github.com/autometrics-dev/autometrics-ts/blob/06ff7739ccd82f2a1d382f3b0d62c906ea72956a/packages/autometrics/src/platform.deno.ts#L130-L144) platforms should be ported as well.

additionally, i had a troublesome time getting the `just build-all` command to work when trying to prepare this for a proper release/pr. please let me know how to proceed with getting this merged in. it is currently blocking my adoption of autometrics which otherwise looks to be of great benefit to me.


node profile ouput (sample)
```
 [Bottom up (heavy) profile]:
  Note: percentage shows a share of a particular caller in the total
  amount of its parent calls.
  Callers occupying less than 1.0% are not shown.

   ticks parent  name
   9335   64.6%  /usr/local/bin/node
   4380   46.9%    LazyCompile: *uvException node:internal/errors:511:57
   4380  100.0%      LazyCompile: *readFileSync node:fs:468:22
   4371   99.8%        LazyCompile: *readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
   4371  100.0%          LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
   4371  100.0%            LazyCompile: ~getRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:517:30
   3742   40.1%    LazyCompile: *readFileSync node:fs:468:22
   3735   99.8%      LazyCompile: *readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
   3735  100.0%        LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
   3735  100.0%          LazyCompile: ~getRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:517:30
   3735  100.0%            LazyCompile: ~getDefaultValue /app/node_modules/@autometrics/autometrics/index.cjs:715:25
    299    3.2%    /usr/local/bin/node
    270   90.3%      LazyCompile: *readFileSync node:fs:468:22
    270  100.0%        LazyCompile: *readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
    270  100.0%          LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
    270  100.0%            LazyCompile: ~getRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:517:30
     10    3.3%      LazyCompile: *uvException node:internal/errors:511:57
     10  100.0%        LazyCompile: *readFileSync node:fs:468:22
     10  100.0%          LazyCompile: *readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
     10  100.0%            LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
    280    3.0%    LazyCompile: *readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
    280  100.0%      LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
    280  100.0%        LazyCompile: ~getRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:517:30
    280  100.0%          LazyCompile: ~getDefaultValue /app/node_modules/@autometrics/autometrics/index.cjs:715:25
    280  100.0%            LazyCompile: ~recordBuildInfo /app/node_modules/@autometrics/autometrics/index.cjs:695:29
    170    1.8%    LazyCompile: *isErrorStackTraceLimitWritable node:internal/errors:205:40
    170  100.0%      LazyCompile: *uvException node:internal/errors:511:57
    170  100.0%        LazyCompile: *readFileSync node:fs:468:22
    167   98.2%          LazyCompile: *readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
    167  100.0%            LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
      3    1.8%          Function: ^readClosest /app/node_modules/@autometrics/autometrics/index.cjs:566:21
      3  100.0%            LazyCompile: ~detectRepositoryUrl /app/node_modules/@autometrics/autometrics/index.cjs:560:29
    105    1.1%    Function: ^internalCompileFunction node:internal/vm:31:33
    104   99.0%      Function: ^wrapSafe node:internal/modules/cjs/loader:1154:18
    104  100.0%        Function: ^Module._compile node:internal/modules/cjs/loader:1210:37
    103   99.0%          Function: ^Module._extensions..js node:internal/modules/cjs/loader:1265:37
    102   99.0%            Function: ^Module.load node:internal/modules/cjs/loader:1107:33
```

`just build-all` error
```
~/Development/autometrics-ts/examples/fastify ~/Development/autometrics-ts
+ just build
yarn && yarn build
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: ENOENT: no such file or directory, readlink '/Users/benji/Development/autometrics-ts/dist/autometrics/node_modules/@types/node'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'readlink',
  path: '/Users/benji/Development/autometrics-ts/dist/autometrics/node_modules/@types/node'
}
error: Recipe `build` failed on line 2 with exit code 1
error: Recipe `build-examples` failed with exit code 1
```