### PR TITLE
make getModulePath ignore reflect metadata module

### DIFF
--- a/packages/autometrics/src/utils.ts
+++ b/packages/autometrics/src/utils.ts
@@ -92,10 +92,14 @@ function getWrappedFunctionPath(): string | undefined {
       return (
         index > 2 &&
         file &&
+        // Ignore autometrics internals
         !file.includes("autometrics/index.cjs") &&
         !file.includes("autometrics/index.mjs") &&
         !file.includes("wrappers.ts") &&
         !file.includes("wrappers.js") &&
+        // Ignore reflect-metadata - often used by IOC libraries for runtime dependency injection
+        // Without this, instrumented functions will be attributed to this module rather than
+        // the module the function truly belongs to
         !file.includes("reflect-metadata")
       );
     });

--- a/packages/autometrics/src/utils.ts
+++ b/packages/autometrics/src/utils.ts
@@ -95,7 +95,8 @@ function getWrappedFunctionPath(): string | undefined {
         !file.includes("autometrics/index.cjs") &&
         !file.includes("autometrics/index.mjs") &&
         !file.includes("wrappers.ts") &&
-        !file.includes("wrappers.js")
+        !file.includes("wrappers.js") &&
+        !file.includes("reflect-metadata")
       );
     });
     return call?.file;


### PR DESCRIPTION
when using an IOC container that relies on the reflect-metadata package (like InversifyJS), all functions in the app which are injected at runtime are attributed to the reflect metadata module, rather than the actual file that they are in.

this fixes that.

before:
<img width="407" alt="image" src="https://github.com/autometrics-dev/autometrics-ts/assets/44608192/f96a12be-8c8b-4215-b251-d231dc5e7939">

after:
<img width="409" alt="image" src="https://github.com/autometrics-dev/autometrics-ts/assets/44608192/1eefb843-bdc2-4b9e-8699-9b4c1d3b941b">
